### PR TITLE
feat: Filt subresource in obs signer

### DIFF
--- a/src/services/huaweicloud/mod.rs
+++ b/src/services/huaweicloud/mod.rs
@@ -7,3 +7,4 @@ pub mod obs;
 mod constants;
 mod credential;
 mod loader;
+mod subresource;

--- a/src/services/huaweicloud/obs.rs
+++ b/src/services/huaweicloud/obs.rs
@@ -15,6 +15,7 @@ use super::loader::{CredentialLoad, CredentialLoadChain};
 use crate::hash::base64_hmac_sha1;
 use crate::request::SignableRequest;
 use crate::services::huaweicloud::loader::EnvLoader;
+use crate::services::huaweicloud::subresource::is_subresource_param;
 use crate::time::{self, DateTime};
 
 /// Builder for `Signer`.
@@ -286,7 +287,9 @@ fn canonicalize_resource(req: &impl SignableRequest, bucket: &str) -> Result<Str
     write!(&mut s, "{}", req.path())?;
 
     let mut params: Vec<(Cow<'_, str>, Cow<'_, str>)> =
-        form_urlencoded::parse(req.query().unwrap_or_default().as_bytes()).collect();
+        form_urlencoded::parse(req.query().unwrap_or_default().as_bytes())
+            .filter(|(k, _)| is_subresource_param(k))
+            .collect();
     // Sort by param name
     params.sort();
 

--- a/src/services/huaweicloud/subresource.rs
+++ b/src/services/huaweicloud/subresource.rs
@@ -1,0 +1,72 @@
+use once_cell::sync::Lazy;
+use std::collections::HashSet;
+
+static SUBRESOURCES: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    HashSet::from([
+        "CDNNotifyConfiguration",
+        "acl",
+        "append",
+        "attname",
+        "backtosource",
+        "cors",
+        "customdomain",
+        "delete",
+        "deletebucket",
+        "directcoldaccess",
+        "encryption",
+        "inventory",
+        "length",
+        "lifecycle",
+        "location",
+        "logging",
+        "metadata",
+        "modify",
+        "name",
+        "notification",
+        "partNumber",
+        "policy",
+        "position",
+        "quota",
+        "rename",
+        "replication",
+        "response-cache-control",
+        "response-content-disposition",
+        "response-content-encoding",
+        "response-content-language",
+        "response-content-type",
+        "response-expires",
+        "restore",
+        "storageClass",
+        "storagePolicy",
+        "storageinfo",
+        "tagging",
+        "torrent",
+        "truncate",
+        "uploadId",
+        "uploads",
+        "versionId",
+        "versioning",
+        "versions",
+        "website",
+        "x-image-process",
+        "x-image-save-bucket",
+        "x-image-save-object",
+        "x-obs-security-token",
+    ])
+});
+
+pub(super) fn is_subresource_param(param: &str) -> bool {
+    SUBRESOURCES.contains(param)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_a() {
+        assert!(is_subresource_param("CDNNotifyConfiguration"));
+        assert!(is_subresource_param("acl"));
+        assert!(!is_subresource_param("delimiter"));
+    }
+}

--- a/src/services/huaweicloud/subresource.rs
+++ b/src/services/huaweicloud/subresource.rs
@@ -1,6 +1,7 @@
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
 
+// Please attention: the subsources are case sensitive.
 static SUBRESOURCES: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     HashSet::from([
         "CDNNotifyConfiguration",


### PR DESCRIPTION
https://support.huaweicloud.com/intl/en-us/api-obs/obs_04_0010.html

In OBS, we can only add specific subresource params in the CanonicalizedResource, and other params should be discarded.

e.g. For a list object request:

> GET /?delimiter=/

The CanonicalizedResource is `/bucket/`, not `/bucket/?delimiter=/`, since `delimiter` is not a subresource.