### PR TITLE
refactor: disable default features for `ureq`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1"
 sha1 = "0.10"
 sha2 = "0.10"
 time = { version = "0.3", features = ["macros", "formatting", "parsing"] }
-ureq = "2.5"
+ureq = { version = "2.5", default-features = false }
 
 [dev-dependencies]
 aws-sigv4 = "0.51"

--- a/src/google/signer.rs
+++ b/src/google/signer.rs
@@ -77,7 +77,7 @@ impl Builder {
         };
 
         let credential_content = match &self.credential {
-            CredentialLoader::Path(v) => std::fs::read(&v)?,
+            CredentialLoader::Path(v) => std::fs::read(v)?,
             CredentialLoader::Content(v) => base64_decode(v),
             CredentialLoader::None => match env::var(GOOGLE_APPLICATION_CREDENTIALS) {
                 Ok(v) => std::fs::read(&v)?,


### PR DESCRIPTION
Avoid pulling `rustls`.

Prerequisite for https://github.com/datafuselabs/opendal/issues/812