### PR TITLE
Add support for creating an azure credential with a SAS token

### DIFF
--- a/src/aliyun/credential.rs
+++ b/src/aliyun/credential.rs
@@ -114,7 +114,9 @@ impl CredentialLoader {
             self.config_loader.access_key_secret(),
         ) {
             let mut cred = Credential::new(&ak, &sk);
-            cred.set_security_token(self.config_loader.security_token().as_deref());
+            if let Some(tk) = self.config_loader.security_token() {
+                cred.set_security_token(&tk);
+            }
             Some(cred)
         } else {
             None

--- a/src/aws/credential.rs
+++ b/src/aws/credential.rs
@@ -211,7 +211,9 @@ impl CredentialLoader {
             self.config_loader.secret_access_key(),
         ) {
             let mut cred = Credential::new(&ak, &sk);
-            cred.set_security_token(self.config_loader.session_token().as_deref());
+            if let Some(tk) = self.config_loader.session_token() {
+                cred.set_security_token(&tk);
+            }
             Some(cred)
         } else {
             None
@@ -230,7 +232,9 @@ impl CredentialLoader {
             self.config_loader.secret_access_key(),
         ) {
             let mut cred = Credential::new(&ak, &sk);
-            cred.set_security_token(self.config_loader.session_token().as_deref());
+            if let Some(tk) = self.config_loader.session_token() {
+                cred.set_security_token(&tk);
+            }
             Some(cred)
         } else {
             None

--- a/src/aws/v4.rs
+++ b/src/aws/v4.rs
@@ -90,7 +90,7 @@ impl Builder {
     /// Security token always come with an expires in, be aware to refresh
     /// expired security_token
     pub fn security_token(&mut self, security_token: &str) -> &mut Self {
-        self.credential.set_security_token(Some(security_token));
+        self.credential.set_security_token(security_token);
         self
     }
 

--- a/src/azure/storage/signer.rs
+++ b/src/azure/storage/signer.rs
@@ -122,7 +122,8 @@ impl Signer {
         } else {
             let now = self.time.unwrap_or_else(time::now);
             let string_to_sign = string_to_sign(req, cred, now)?;
-            let auth = base64_hmac_sha256(&base64_decode(cred.secret_key()), string_to_sign.as_bytes());
+            let auth =
+                base64_hmac_sha256(&base64_decode(cred.secret_key()), string_to_sign.as_bytes());
 
             Ok(SignedOutput::SharedKey {
                 account_name: cred.access_key().to_string(),
@@ -137,7 +138,7 @@ impl Signer {
         match output {
             SignedOutput::SharedAccessSignature(sas_token) => {
                 // The SAS token is itself a query string
-                return req.set_query(sas_token)
+                return req.set_query(sas_token);
             }
             SignedOutput::SharedKey {
                 account_name,
@@ -216,7 +217,7 @@ pub enum SignedOutput {
         signed_time: DateTime,
         signature: String,
     },
-    SharedAccessSignature(String)
+    SharedAccessSignature(String),
 }
 
 /// Construct string to sign
@@ -342,7 +343,7 @@ fn canonicalize_resource(req: &impl SignableRequest, cred: &Credential) -> Strin
 
 #[cfg(test)]
 mod tests {
-    use http::{Request};
+    use http::Request;
 
     use crate::AzureStorageSigner;
 

--- a/src/azure/storage/signer.rs
+++ b/src/azure/storage/signer.rs
@@ -42,6 +42,14 @@ impl Builder {
         self
     }
 
+    /// Specify a Shared Access Signature (SAS) token.
+    /// * ref: [Grant limited access to Azure Storage resources using shared access signatures (SAS)](https://docs.microsoft.com/azure/storage/common/storage-sas-overview)
+    /// * ref: [Create SAS tokens for storage containers](https://docs.microsoft.com/azure/applied-ai-services/form-recognizer/create-sas-tokens)
+    pub fn security_token(&mut self, security_token: &str) -> &mut Self {
+        self.credential.set_security_token(security_token);
+        self
+    }
+
     /// Specify the signing time.
     ///
     /// # Note

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -79,7 +79,9 @@ impl Credential {
 
     /// is current cred is valid?
     pub fn is_valid(&self) -> bool {
-        if (self.access_key.is_empty() || self.secret_key.is_empty()) && self.security_token.is_none() {
+        if (self.access_key.is_empty() || self.secret_key.is_empty())
+            && self.security_token.is_none()
+        {
             return false;
         }
         // Take 120s as buffer to avoid edge cases.

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -79,7 +79,7 @@ impl Credential {
 
     /// is current cred is valid?
     pub fn is_valid(&self) -> bool {
-        if self.access_key.is_empty() || self.secret_key.is_empty() {
+        if (self.access_key.is_empty() || self.secret_key.is_empty()) && self.security_token.is_none() {
             return false;
         }
         // Take 120s as buffer to avoid edge cases.

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -56,8 +56,8 @@ impl Credential {
         self.security_token.as_deref()
     }
     /// Set security_token
-    pub fn set_security_token(&mut self, token: Option<&str>) -> &mut Self {
-        self.security_token = token.map(|v| v.to_string());
+    pub fn set_security_token(&mut self, token: &str) -> &mut Self {
+        self.security_token = Some(token.to_string());
         self
     }
     /// Build a credential with security_token


### PR DESCRIPTION
Right now the only auth system supported for Azure Blobs is Shared Key, which is not recommended. Shared Access Signatures are better and provide more fine-grained account control.