### PR TITLE
feat: Add sign_query support for google

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ sha1 = "0.10"
 sha2 = "0.10"
 time = { version = "0.3", features = ["macros", "formatting", "parsing"] }
 ureq = { version = "2.5", default-features = false }
+rand = "0.8.5"
+rsa = { version = "0.8.1", features = ["sha2"] }
 
 [dev-dependencies]
 aws-sigv4 = "0.54"

--- a/src/google/constants.rs
+++ b/src/google/constants.rs
@@ -4,11 +4,7 @@ use percent_encoding::NON_ALPHANUMERIC;
 // Env values used in google services.
 pub const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
 
-// Headers used in aws services.
-pub const X_GOOG_CONTENT_SHA_256: &str = "x-goog-content-sha256";
-pub const X_GOOG_DATE: &str = "x-goog-date";
-
-/// AsciiSet for [AWS UriEncode](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)
+/// AsciiSet for [Google UriEncode](https://cloud.google.com/storage/docs/authentication/canonical-requests)
 ///
 /// - URI encode every byte except the unreserved characters: 'A'-'Z', 'a'-'z', '0'-'9', '-', '.', '_', and '~'.
 pub static GOOG_URI_ENCODE_SET: AsciiSet = NON_ALPHANUMERIC
@@ -18,7 +14,7 @@ pub static GOOG_URI_ENCODE_SET: AsciiSet = NON_ALPHANUMERIC
     .remove(b'_')
     .remove(b'~');
 
-/// AsciiSet for [AWS UriEncode](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)
+/// AsciiSet for [Google UriEncode](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)
 ///
 /// But used in query.
 pub static GOOG_QUERY_ENCODE_SET: AsciiSet = NON_ALPHANUMERIC

--- a/src/google/constants.rs
+++ b/src/google/constants.rs
@@ -1,2 +1,28 @@
+use percent_encoding::AsciiSet;
+use percent_encoding::NON_ALPHANUMERIC;
+
 // Env values used in google services.
 pub const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
+
+// Headers used in aws services.
+pub const X_GOOG_CONTENT_SHA_256: &str = "x-goog-content-sha256";
+pub const X_GOOG_DATE: &str = "x-goog-date";
+
+/// AsciiSet for [AWS UriEncode](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)
+///
+/// - URI encode every byte except the unreserved characters: 'A'-'Z', 'a'-'z', '0'-'9', '-', '.', '_', and '~'.
+pub static GOOG_URI_ENCODE_SET: AsciiSet = NON_ALPHANUMERIC
+    .remove(b'/')
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
+/// AsciiSet for [AWS UriEncode](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)
+///
+/// But used in query.
+pub static GOOG_QUERY_ENCODE_SET: AsciiSet = NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');

--- a/src/google/credential.rs
+++ b/src/google/credential.rs
@@ -395,7 +395,7 @@ impl CredentialLoader {
         Ok(Some(token))
     }
 
-    fn load_credential(&self) -> Option<Credential> {
+    pub fn load_credential(&self) -> Option<Credential> {
         // Return cached credential if it has been loaded at least once.
         if self.credential_loaded.load(Ordering::Relaxed) {
             if let Some(cred) = self.credential.read().expect("lock poisoned").clone() {

--- a/src/google/mod.rs
+++ b/src/google/mod.rs
@@ -3,6 +3,7 @@
 mod constants;
 mod credential;
 mod signer;
+mod v4;
 pub use credential::Token;
 pub use credential::TokenLoad;
 pub use signer::Builder;

--- a/src/google/signer.rs
+++ b/src/google/signer.rs
@@ -313,7 +313,6 @@ mod tests {
         signer.sign_query(&mut req, time::Duration::hours(1))?;
 
         let query = req.query().unwrap();
-        println!("query: {}", query);
         assert!(query.contains("X-Goog-Algorithm=GOOG4-RSA-SHA256"));
         assert!(query.contains("X-Goog-Credential"));
 

--- a/src/google/v4.rs
+++ b/src/google/v4.rs
@@ -1,0 +1,955 @@
+//! AWS service sigv4 signer
+
+use std::borrow::Cow;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::Write;
+
+use anyhow::anyhow;
+use anyhow::Result;
+use http::HeaderMap;
+use http::HeaderValue;
+use log::debug;
+use percent_encoding::percent_decode_str;
+use percent_encoding::utf8_percent_encode;
+
+use super::constants::GOOG_QUERY_ENCODE_SET;
+use super::constants::X_GOOG_CONTENT_SHA_256;
+use super::constants::X_GOOG_DATE;
+
+use crate::google::credential::Credential;
+use crate::hash::hex_sha256;
+use crate::request::SignableRequest;
+use crate::time::format_date;
+use crate::time::format_iso8601;
+use crate::time::DateTime;
+use crate::time::Duration;
+use crate::time::{self};
+
+use rsa::pkcs1v15::SigningKey;
+use rsa::signature::RandomizedSigner;
+
+/// Builder for `Signer`.
+#[derive(Default)]
+pub struct Builder {
+    service: Option<String>,
+    region: Option<String>,
+    // config_loader: ConfigLoader,
+    // credential_loader: Option<CredentialLoader>,
+    credential: Option<Credential>,
+    allow_anonymous: bool,
+
+    time: Option<DateTime>,
+}
+
+impl Builder {
+    /// Specify service like "s3".
+    pub fn service(&mut self, service: &str) -> &mut Self {
+        self.service = Some(service.to_string());
+        self
+    }
+
+    /// Specify region like "us-east-1".
+    /// If not set, use "auto" instead.
+    pub fn region(&mut self, region: &str) -> &mut Self {
+        self.region = Some(region.to_string());
+        self
+    }
+
+    /// Allow anonymous request if credential is not loaded.
+    #[allow(dead_code)]
+    pub fn allow_anonymous(&mut self) -> &mut Self {
+        self.allow_anonymous = true;
+        self
+    }
+
+    /// Specify the credential
+    pub fn credential(&mut self, cred: Credential) -> &mut Self {
+        self.credential = Some(cred);
+        self
+    }
+
+    /// Specify the signing time.
+    ///
+    /// # Note
+    ///
+    /// We should always take current time to sign requests.
+    /// Only use this function for testing.
+    #[cfg(test)]
+    pub fn time(&mut self, time: DateTime) -> &mut Self {
+        self.time = Some(time);
+        self
+    }
+
+    /// Use exising information to build a new signer.
+    ///
+    /// The builder should not be used anymore.
+    pub fn build(&mut self) -> Result<Signer> {
+        let service = self
+            .service
+            .as_ref()
+            .ok_or_else(|| anyhow!("service is required"))?;
+        debug!("signer: service: {:?}", service);
+
+        let region = self.region.take().unwrap_or_else(|| "auto".to_string());
+        let credential = self.credential.take();
+
+        Ok(Signer {
+            service: service.to_string(),
+            region,
+            credential,
+            allow_anonymous: self.allow_anonymous,
+            time: self.time,
+        })
+    }
+}
+
+/// Singer that implement Google     SigV4.
+///
+/// - [Signature Version 4 signing process](https://cloud.google.com/storage/docs/access-control/signing-urls-manually)
+pub struct Signer {
+    service: String,
+    region: String,
+    credential: Option<Credential>,
+
+    /// Allow anonymous request if credential is not loaded.
+    allow_anonymous: bool,
+
+    time: Option<DateTime>,
+}
+
+impl Signer {
+    /// Create a builder.
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+
+    /// Get credential
+    ///
+    /// # Note
+    ///
+    /// This function should never be exported to avoid credential leaking by
+    /// mistake.
+    fn credential(&self) -> &Option<Credential> {
+        &self.credential
+    }
+
+    fn canonicalize(
+        &self,
+        req: &impl SignableRequest,
+        method: SigningMethod,
+        cred: &Credential,
+    ) -> Result<CanonicalRequest> {
+        let mut creq = CanonicalRequest::new(req, method, self.time)?;
+        creq.build_headers()?;
+        creq.build_query(cred, &self.service, &self.region)?;
+
+        debug!("calculated canonical request: {creq}");
+        Ok(creq)
+    }
+
+    /// Calculate signing requests via SignableRequest.
+    fn calculate(&self, mut creq: CanonicalRequest, cred: &Credential) -> Result<CanonicalRequest> {
+        let encoded_req = hex_sha256(creq.to_string().as_bytes());
+
+        // Scope: "20220313/<region>/<service>/goog4_request"
+        let scope = format!(
+            "{}/{}/{}/goog4_request",
+            format_date(creq.signing_time),
+            self.region,
+            self.service
+        );
+        debug!("calculated scope: {scope}");
+
+        // StringToSign:
+        //
+        // GOOG4-RSA-SHA256
+        // 20220313T072004Z
+        // 20220313/<region>/<service>/goog4_request
+        // <hashed_canonical_request>
+        let string_to_sign = {
+            let mut f = String::new();
+            writeln!(f, "GOOG4-RSA-SHA256")?;
+            writeln!(f, "{}", format_iso8601(creq.signing_time))?;
+            writeln!(f, "{}", &scope)?;
+            write!(f, "{}", &encoded_req)?;
+            f
+        };
+        debug!("calculated string to sign: {string_to_sign}");
+
+        use rsa::pkcs8::DecodePrivateKey;
+
+        let mut rng = rand::thread_rng();
+        let private_key = rsa::RsaPrivateKey::from_pkcs8_pem(cred.private_key())?;
+        let signing_key = SigningKey::<rsa::sha2::Sha256>::new_with_prefix(private_key);
+        let signature = signing_key.sign_with_rng(&mut rng, string_to_sign.as_bytes());
+        let signature = signature.to_string();
+
+        match creq.signing_method {
+            SigningMethod::Header => {
+                let mut authorization = HeaderValue::from_str(&format!(
+                    "GOOG4-RSA-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
+                    cred.client_email(),
+                    scope,
+                    creq.signed_headers().join(";"),
+                    signature
+                ))?;
+                authorization.set_sensitive(true);
+
+                creq.headers
+                    .insert(http::header::AUTHORIZATION, authorization);
+            }
+            SigningMethod::Query(_) => {
+                let mut query = creq
+                    .query
+                    .take()
+                    .expect("query must be valid in query signing");
+                write!(query, "&X-Goog-Signature={signature}")?;
+
+                creq.query = Some(query);
+            }
+        }
+
+        Ok(creq)
+    }
+
+    /// Apply signed results to requests.
+    fn apply(&self, req: &mut impl SignableRequest, creq: CanonicalRequest) -> Result<()> {
+        for (header, value) in creq.headers.into_iter() {
+            req.insert_header(
+                header.expect("header must contain only once"),
+                value.clone(),
+            )?;
+        }
+
+        if let Some(query) = creq.query {
+            req.set_query(&query)?;
+        }
+
+        Ok(())
+    }
+
+    /// Signing request with header.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use anyhow::Result;
+    /// use reqsign::AwsConfigLoader;
+    /// use reqsign::AwsV4Signer;
+    /// use reqwest::Client;
+    /// use reqwest::Request;
+    /// use reqwest::Url;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     // Signer will load region and credentials from environment by default.
+    ///     let signer = AwsV4Signer::builder()
+    ///         .config_loader(AwsConfigLoader::with_loaded())
+    ///         .service("s3")
+    ///         .allow_anonymous()
+    ///         .build()?;
+    ///     // Construct request
+    ///     let url = Url::parse("https://s3.amazonaws.com/testbucket")?;
+    ///     let mut req = reqwest::Request::new(http::Method::GET, url);
+    ///     // Signing request with Signer
+    ///     signer.sign(&mut req)?;
+    ///     // Sending already signed request.
+    ///     let resp = Client::new().execute(req).await?;
+    ///     println!("resp got status: {}", resp.status());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[allow(dead_code)]
+    pub fn sign(&self, req: &mut impl SignableRequest) -> Result<()> {
+        if let Some(cred) = self.credential() {
+            let creq = self.canonicalize(req, SigningMethod::Header, cred)?;
+            let creq = self.calculate(creq, cred)?;
+            return self.apply(req, creq);
+        }
+
+        if self.allow_anonymous {
+            debug!("credential not found and anonymous is allowed, skipping signing.");
+            return Ok(());
+        }
+
+        Err(anyhow!("credential not found"))
+    }
+
+    /// Signing request with query.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use anyhow::Result;
+    /// use reqsign::AwsConfigLoader;
+    /// use reqsign::AwsV4Signer;
+    /// use reqwest::Client;
+    /// use reqwest::Request;
+    /// use reqwest::Url;
+    /// use time::Duration;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     // Signer will load region and credentials from environment by default.
+    ///     let signer = AwsV4Signer::builder()
+    ///         .config_loader(AwsConfigLoader::with_loaded())
+    ///         .service("s3")
+    ///         .allow_anonymous()
+    ///         .build()?;
+    ///     // Construct request
+    ///     let url = Url::parse("https://s3.amazonaws.com/testbucket")?;
+    ///     let mut req = reqwest::Request::new(http::Method::GET, url);
+    ///     // Signing request with Signer
+    ///     signer.sign_query(&mut req, Duration::hours(1))?;
+    ///     // Sending already signed request.
+    ///     let resp = Client::new().execute(req).await?;
+    ///     println!("resp got status: {}", resp.status());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn sign_query(&self, req: &mut impl SignableRequest, expire: Duration) -> Result<()> {
+        let credential = self.credential().as_ref().unwrap();
+        let creq = self.canonicalize(req, SigningMethod::Query(expire), credential)?;
+        let creq = self.calculate(creq, credential)?;
+        self.apply(req, creq)
+    }
+}
+
+impl Debug for Signer {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Signer {{ region: {}, service: {}, allow_anonymous: {} }}",
+            self.region, self.service, self.allow_anonymous
+        )
+    }
+}
+
+/// SigningMethod is the method that used in signing.
+#[derive(Copy, Clone)]
+pub enum SigningMethod {
+    /// Signing with header.
+    Header,
+    /// Signing with query.
+    Query(Duration),
+}
+
+#[derive(Clone)]
+struct CanonicalRequest {
+    method: http::Method,
+    path: String,
+    query: Option<String>,
+    headers: HeaderMap,
+
+    signing_host: String,
+    signing_method: SigningMethod,
+    signing_time: DateTime,
+}
+
+impl CanonicalRequest {
+    fn new(
+        req: &impl SignableRequest,
+        method: SigningMethod,
+        now: Option<DateTime>,
+    ) -> Result<Self> {
+        let mut canonical_headers = HeaderMap::with_capacity(req.headers().len());
+        // Header names and values need to be normalized according to Step 4 of https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+        // Using append instead of insert means this will not clobber headers that have the same lowercase name
+        for (name, value) in req.headers().iter() {
+            // The user agent header should not be canonical because it may be altered by proxies
+            if name == http::header::USER_AGENT {
+                continue;
+            }
+            canonical_headers.append(name, normalize_header_value(value));
+        }
+
+        Ok(CanonicalRequest {
+            method: req.method(),
+            path: percent_decode_str(req.path()).decode_utf8()?.to_string(),
+            query: req.query().map(|v| v.to_string()),
+            headers: req.headers(),
+
+            signing_host: req.host_port(),
+            signing_method: method,
+            signing_time: now.unwrap_or_else(time::now),
+        })
+    }
+
+    fn build_headers(&mut self) -> Result<()> {
+        // Insert HOST header if not present.
+        if self.headers.get(&http::header::HOST).is_none() {
+            let header = HeaderValue::try_from(self.signing_host.to_string())?;
+            self.headers.insert(http::header::HOST, header);
+        }
+
+        if matches!(self.signing_method, SigningMethod::Header) {
+            // Insert DATE header if not present.
+            if self.headers.get(X_GOOG_DATE).is_none() {
+                let date_header = HeaderValue::try_from(format_iso8601(self.signing_time))?;
+                self.headers.insert(X_GOOG_DATE, date_header);
+            }
+
+            // Insert X_GOOG_CONTENT_SHA_256 header if not present.
+            if self.headers.get(X_GOOG_CONTENT_SHA_256).is_none() {
+                self.headers.insert(
+                    X_GOOG_CONTENT_SHA_256,
+                    HeaderValue::from_static("UNSIGNED-PAYLOAD"),
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn signed_headers(&self) -> Vec<&str> {
+        let mut signed_headers = self.headers.keys().map(|v| v.as_str()).collect::<Vec<_>>();
+        signed_headers.sort_unstable();
+
+        signed_headers
+    }
+
+    fn build_query(&mut self, cred: &Credential, service: &str, region: &str) -> Result<()> {
+        let query = self.query.take().unwrap_or_default();
+        let mut params: Vec<_> = form_urlencoded::parse(query.as_bytes()).collect();
+
+        if let SigningMethod::Query(expire) = self.signing_method {
+            params.push(("X-Goog-Algorithm".into(), "GOOG4-RSA-SHA256".into()));
+            params.push((
+                "X-Goog-Credential".into(),
+                Cow::Owned(format!(
+                    "{}/{}/{}/{}/goog4_request",
+                    cred.client_email(),
+                    format_date(self.signing_time),
+                    region,
+                    service
+                )),
+            ));
+            params.push((
+                "X-Goog-Date".into(),
+                Cow::Owned(format_iso8601(self.signing_time)),
+            ));
+            params.push((
+                "X-Goog-Expires".into(),
+                Cow::Owned(expire.whole_seconds().to_string()),
+            ));
+            params.push((
+                "X-Goog-SignedHeaders".into(),
+                self.signed_headers().join(";").into(),
+            ));
+        }
+        // Sort by param name
+        params.sort();
+
+        if params.is_empty() {
+            return Ok(());
+        }
+
+        let param = params
+            .iter()
+            .map(|(k, v)| {
+                (
+                    utf8_percent_encode(k, &GOOG_QUERY_ENCODE_SET),
+                    utf8_percent_encode(v, &GOOG_QUERY_ENCODE_SET),
+                )
+            })
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<String>>()
+            .join("&");
+        self.query = Some(param);
+
+        Ok(())
+    }
+}
+
+impl Display for CanonicalRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}", self.method)?;
+        writeln!(
+            f,
+            "{}",
+            utf8_percent_encode(&self.path, &super::constants::GOOG_URI_ENCODE_SET)
+        )?;
+        writeln!(f, "{}", self.query.as_ref().unwrap_or(&"".to_string()))?;
+
+        let signed_headers = self.signed_headers();
+        for header in signed_headers.iter() {
+            let value = &self.headers[*header];
+            writeln!(
+                f,
+                "{}:{}",
+                header,
+                value.to_str().expect("header value must be valid")
+            )?;
+        }
+        writeln!(f)?;
+        writeln!(f, "{}", signed_headers.join(";"))?;
+        // TODO: we should support user specify payload hash.
+        write!(f, "UNSIGNED-PAYLOAD")?;
+
+        Ok(())
+    }
+}
+
+fn normalize_header_value(header_value: &HeaderValue) -> HeaderValue {
+    let bs = header_value.as_bytes();
+
+    let starting_index = bs.iter().position(|b| *b != b' ').unwrap_or(0);
+    let ending_offset = bs.iter().rev().position(|b| *b != b' ').unwrap_or(0);
+    let ending_index = bs.len() - ending_offset;
+
+    // This can't fail because we started with a valid HeaderValue and then only trimmed spaces
+    HeaderValue::from_bytes(&bs[starting_index..ending_index]).expect("invalid header value")
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use std::time::SystemTime;
+
+//     use anyhow::Result;
+//     use aws_sigv4;
+//     use aws_sigv4::http_request::PayloadChecksumKind;
+//     use aws_sigv4::http_request::PercentEncodingMode;
+//     use aws_sigv4::http_request::SignableBody;
+//     use aws_sigv4::http_request::SignableRequest;
+//     use aws_sigv4::http_request::SignatureLocation;
+//     use aws_sigv4::http_request::SigningSettings;
+//     use aws_sigv4::SigningParams;
+//     use http::header;
+
+//     use super::*;
+
+//     fn test_get_request() -> http::Request<&'static str> {
+//         let mut req = http::Request::new("");
+//         *req.method_mut() = http::Method::GET;
+//         *req.uri_mut() = "http://127.0.0.1:9000/hello"
+//             .parse()
+//             .expect("url must be valid");
+
+//         req
+//     }
+
+//     fn test_get_request_with_sse() -> http::Request<&'static str> {
+//         let mut req = http::Request::new("");
+//         *req.method_mut() = http::Method::GET;
+//         *req.uri_mut() = "http://127.0.0.1:9000/hello"
+//             .parse()
+//             .expect("url must be valid");
+//         req.headers_mut().insert(
+//             "x-goog-server-side-encryption",
+//             "a".parse().expect("must be valid"),
+//         );
+//         req.headers_mut().insert(
+//             "x-goog-server-side-encryption-customer-algorithm",
+//             "b".parse().expect("must be valid"),
+//         );
+//         req.headers_mut().insert(
+//             "x-goog-server-side-encryption-customer-key",
+//             "c".parse().expect("must be valid"),
+//         );
+//         req.headers_mut().insert(
+//             "x-goog-server-side-encryption-customer-key-md5",
+//             "d".parse().expect("must be valid"),
+//         );
+//         req.headers_mut().insert(
+//             "x-goog-server-side-encryption-aws-kms-key-id",
+//             "e".parse().expect("must be valid"),
+//         );
+
+//         req
+//     }
+
+//     fn test_get_request_with_query() -> http::Request<&'static str> {
+//         let mut req = http::Request::new("");
+//         *req.method_mut() = http::Method::GET;
+//         *req.uri_mut() = "http://127.0.0.1:9000/hello?list-type=2&max-keys=3&prefix=CI/&start-after=ExampleGuide.pdf"
+//             .parse()
+//             .expect("url must be valid");
+
+//         req
+//     }
+
+//     fn test_get_request_virtual_host() -> http::Request<&'static str> {
+//         let mut req = http::Request::new("");
+//         *req.method_mut() = http::Method::GET;
+//         *req.uri_mut() = "http://hello.s3.test.example.com"
+//             .parse()
+//             .expect("url must be valid");
+
+//         req
+//     }
+
+//     fn test_get_request_with_query_virtual_host() -> http::Request<&'static str> {
+//         let mut req = http::Request::new("");
+//         *req.method_mut() = http::Method::GET;
+//         *req.uri_mut() = "http://hello.s3.test.example.com?list-type=2&max-keys=3&prefix=CI/&start-after=ExampleGuide.pdf"
+//             .parse()
+//             .expect("url must be valid");
+
+//         req
+//     }
+
+//     fn test_put_request() -> http::Request<&'static str> {
+//         let content = "Hello,World!";
+//         let mut req = http::Request::new(content);
+//         *req.method_mut() = http::Method::PUT;
+//         *req.uri_mut() = "http://127.0.0.1:9000/hello"
+//             .parse()
+//             .expect("url must be valid");
+
+//         req.headers_mut().insert(
+//             http::header::CONTENT_LENGTH,
+//             HeaderValue::from_str(&content.len().to_string()).expect("must be valid"),
+//         );
+
+//         req
+//     }
+
+//     fn test_put_request_virtual_host() -> http::Request<&'static str> {
+//         let content = "Hello,World!";
+//         let mut req = http::Request::new(content);
+//         *req.method_mut() = http::Method::PUT;
+//         *req.uri_mut() = "http://hello.s3.test.example.com"
+//             .parse()
+//             .expect("url must be valid");
+
+//         req.headers_mut().insert(
+//             header::CONTENT_LENGTH,
+//             HeaderValue::from_str(&content.len().to_string()).expect("must be valid"),
+//         );
+
+//         req
+//     }
+
+//     fn test_cases() -> &'static [fn() -> http::Request<&'static str>] {
+//         &[
+//             test_get_request,
+//             test_get_request_with_sse,
+//             test_get_request_with_query,
+//             test_get_request_virtual_host,
+//             test_get_request_with_query_virtual_host,
+//             test_put_request,
+//             test_put_request_virtual_host,
+//         ]
+//     }
+
+//     fn compare_request(name: &str, l: &http::Request<&str>, r: &http::Request<&str>) {
+//         fn format_headers(req: &http::Request<&str>) -> Vec<String> {
+//             use crate::request::SignableRequest;
+
+//             let mut hs = req
+//                 .headers()
+//                 .iter()
+//                 .map(|(k, v)| format!("{}:{}", k, v.to_str().expect("must be valid")))
+//                 .collect::<Vec<_>>();
+
+//             // Insert host if original request doesn't have it.
+//             if !hs.contains(&format!("host:{}", req.host_port())) {
+//                 hs.push(format!("host:{}", req.host_port()))
+//             }
+
+//             hs.sort();
+//             hs
+//         }
+
+//         assert_eq!(
+//             format_headers(l),
+//             format_headers(r),
+//             "{name} header mismatch"
+//         );
+
+//         fn format_query(req: &http::Request<&str>) -> Vec<String> {
+//             let query = req.uri().query().unwrap_or_default();
+//             let mut query = form_urlencoded::parse(query.as_bytes())
+//                 .map(|(k, v)| format!("{}={}", &k, &v))
+//                 .collect::<Vec<_>>();
+//             query.sort();
+//             query
+//         }
+
+//         assert_eq!(format_query(l), format_query(r), "{name} query mismatch");
+//     }
+
+//     #[tokio::test]
+//     async fn test_calculate() -> Result<()> {
+//         let _ = env_logger::builder().is_test(true).try_init();
+
+//         for req_fn in test_cases() {
+//             let mut req = req_fn();
+//             let name = format!(
+//                 "{} {} {:?}",
+//                 req.method(),
+//                 req.uri().path(),
+//                 req.uri().query(),
+//             );
+//             let now = time::now();
+
+//             let mut ss = SigningSettings::default();
+//             ss.percent_encoding_mode = PercentEncodingMode::Double;
+//             ss.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
+
+//             let sp = SigningParams::builder()
+//                 .access_key("access_key_id")
+//                 .secret_key("secret_access_key")
+//                 .region("test")
+//                 .service_name("s3")
+//                 .time(SystemTime::from(now))
+//                 .settings(ss)
+//                 .build()
+//                 .expect("signing params must be valid");
+
+//             let output = aws_sigv4::http_request::sign(
+//                 SignableRequest::new(
+//                     req.method(),
+//                     req.uri(),
+//                     req.headers(),
+//                     SignableBody::UnsignedPayload,
+//                 ),
+//                 &sp,
+//             )
+//             .expect("signing must succeed");
+//             let (aws_sig, _) = output.into_parts();
+//             aws_sig.apply_to_request(&mut req);
+//             let expected_req = req;
+
+//             let mut req = req_fn();
+
+//             let signer = Signer::builder()
+//                 .config_loader({
+//                     let cfg = ConfigLoader::default();
+//                     cfg.set_region("test");
+//                     cfg.set_access_key_id("access_key_id");
+//                     cfg.set_secret_access_key("secret_access_key");
+//                     cfg
+//                 })
+//                 .service("s3")
+//                 .time(now)
+//                 .build()?;
+
+//             let cred = signer.credential().expect("credential must be valid");
+//             let creq = signer.canonicalize(&req, SigningMethod::Header, &cred)?;
+//             let actual = signer.calculate(creq, &cred)?;
+//             signer.apply(&mut req, actual).expect("must apply success");
+//             let actual_req = req;
+
+//             compare_request(&name, &expected_req, &actual_req);
+//         }
+
+//         Ok(())
+//     }
+
+//     #[tokio::test]
+//     async fn test_calculate_in_query() -> Result<()> {
+//         let _ = env_logger::builder().is_test(true).try_init();
+
+//         for req_fn in test_cases() {
+//             let mut req = req_fn();
+//             let name = format!(
+//                 "{} {} {:?}",
+//                 req.method(),
+//                 req.uri().path(),
+//                 req.uri().query(),
+//             );
+//             let now = time::now();
+
+//             let mut ss = SigningSettings::default();
+//             ss.percent_encoding_mode = PercentEncodingMode::Double;
+//             ss.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
+//             ss.signature_location = SignatureLocation::QueryParams;
+//             ss.expires_in = Some(std::time::Duration::from_secs(3600));
+
+//             let sp = SigningParams::builder()
+//                 .access_key("access_key_id")
+//                 .secret_key("secret_access_key")
+//                 .region("test")
+//                 .service_name("s3")
+//                 .time(SystemTime::from(now))
+//                 .settings(ss)
+//                 .build()
+//                 .expect("signing params must be valid");
+
+//             let output = aws_sigv4::http_request::sign(
+//                 SignableRequest::new(
+//                     req.method(),
+//                     req.uri(),
+//                     req.headers(),
+//                     SignableBody::UnsignedPayload,
+//                 ),
+//                 &sp,
+//             )
+//             .expect("signing must succeed");
+//             let (aws_sig, _) = output.into_parts();
+//             aws_sig.apply_to_request(&mut req);
+//             let expected_req = req;
+
+//             let mut req = req_fn();
+
+//             let signer = Signer::builder()
+//                 .config_loader({
+//                     let cfg = ConfigLoader::default();
+//                     cfg.set_region("test");
+//                     cfg.set_access_key_id("access_key_id");
+//                     cfg.set_secret_access_key("secret_access_key");
+//                     cfg
+//                 })
+//                 .service("s3")
+//                 .time(now)
+//                 .build()?;
+
+//             let cred = signer.credential().expect("credential must be valid");
+//             let creq =
+//                 signer.canonicalize(&req, SigningMethod::Query(Duration::hours(1)), &cred)?;
+//             let actual = signer.calculate(creq, &cred)?;
+//             signer.apply(&mut req, actual)?;
+//             let actual_req = req;
+
+//             compare_request(&name, &expected_req, &actual_req);
+//         }
+
+//         Ok(())
+//     }
+
+//     #[tokio::test]
+//     async fn test_calculate_with_token() -> Result<()> {
+//         let _ = env_logger::builder().is_test(true).try_init();
+
+//         for req_fn in test_cases() {
+//             let mut req = req_fn();
+//             let name = format!(
+//                 "{} {} {:?}",
+//                 req.method(),
+//                 req.uri().path(),
+//                 req.uri().query(),
+//             );
+//             let now = time::now();
+
+//             let mut ss = SigningSettings::default();
+//             ss.percent_encoding_mode = PercentEncodingMode::Double;
+//             ss.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
+
+//             let sp = SigningParams::builder()
+//                 .access_key("access_key_id")
+//                 .secret_key("secret_access_key")
+//                 .region("test")
+//                 .security_token("security_token")
+//                 .service_name("s3")
+//                 .time(SystemTime::from(now))
+//                 .settings(ss)
+//                 .build()
+//                 .expect("signing params must be valid");
+
+//             let output = aws_sigv4::http_request::sign(
+//                 SignableRequest::new(
+//                     req.method(),
+//                     req.uri(),
+//                     req.headers(),
+//                     SignableBody::UnsignedPayload,
+//                 ),
+//                 &sp,
+//             )
+//             .expect("signing must succeed");
+//             let (aws_sig, _) = output.into_parts();
+//             aws_sig.apply_to_request(&mut req);
+//             let expected_req = req;
+
+//             let mut req = req_fn();
+
+//             let signer = Signer::builder()
+//                 .config_loader({
+//                     let cfg = ConfigLoader::default();
+//                     cfg.set_region("test");
+//                     cfg.set_access_key_id("access_key_id");
+//                     cfg.set_secret_access_key("secret_access_key");
+//                     cfg.set_session_token("security_token");
+//                     cfg
+//                 })
+//                 .service("s3")
+//                 .time(now)
+//                 .build()?;
+
+//             let cred = signer.credential().expect("credential must be valid");
+//             let creq = signer.canonicalize(&req, SigningMethod::Header, &cred)?;
+//             let actual = signer.calculate(creq, &cred)?;
+//             signer.apply(&mut req, actual).expect("must apply success");
+//             let actual_req = req;
+
+//             compare_request(&name, &expected_req, &actual_req);
+//         }
+
+//         Ok(())
+//     }
+
+//     #[tokio::test]
+//     async fn test_calculate_with_token_in_query() -> Result<()> {
+//         let _ = env_logger::builder().is_test(true).try_init();
+
+//         for req_fn in test_cases() {
+//             let mut req = req_fn();
+//             let name = format!(
+//                 "{} {} {:?}",
+//                 req.method(),
+//                 req.uri().path(),
+//                 req.uri().query(),
+//             );
+//             let now = time::now();
+
+//             let mut ss = SigningSettings::default();
+//             ss.percent_encoding_mode = PercentEncodingMode::Double;
+//             ss.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
+//             ss.signature_location = SignatureLocation::QueryParams;
+//             ss.expires_in = Some(std::time::Duration::from_secs(3600));
+
+//             let sp = SigningParams::builder()
+//                 .access_key("access_key_id")
+//                 .secret_key("secret_access_key")
+//                 .region("test")
+//                 .security_token("security_token")
+//                 .service_name("s3")
+//                 .time(SystemTime::from(now))
+//                 .settings(ss)
+//                 .build()
+//                 .expect("signing params must be valid");
+
+//             let output = aws_sigv4::http_request::sign(
+//                 SignableRequest::new(
+//                     req.method(),
+//                     req.uri(),
+//                     req.headers(),
+//                     SignableBody::UnsignedPayload,
+//                 ),
+//                 &sp,
+//             )
+//             .expect("signing must succeed");
+//             let (aws_sig, _) = output.into_parts();
+//             aws_sig.apply_to_request(&mut req);
+//             let expected_req = req;
+
+//             let mut req = req_fn();
+
+//             let signer = Signer::builder()
+//                 .config_loader({
+//                     let cfg = ConfigLoader::default();
+//                     cfg.set_region("test");
+//                     cfg.set_access_key_id("access_key_id");
+//                     cfg.set_secret_access_key("secret_access_key");
+//                     cfg.set_session_token("security_token");
+//                     cfg
+//                 })
+//                 .service("s3")
+//                 .time(now)
+//                 .build()?;
+
+//             let cred = signer.credential().expect("credential must be valid");
+//             let creq =
+//                 signer.canonicalize(&req, SigningMethod::Query(Duration::hours(1)), &cred)?;
+//             let actual = signer.calculate(creq, &cred)?;
+//             signer.apply(&mut req, actual).expect("must apply success");
+//             let actual_req = req;
+
+//             compare_request(&name, &expected_req, &actual_req);
+//         }
+
+//         Ok(())
+//     }
+// }

--- a/testdata/services/google/testbucket_credential.json
+++ b/testdata/services/google/testbucket_credential.json
@@ -1,12 +1,12 @@
 {
   "type": "service_account",
-  "project_id": "noted-throne-361708",
-  "private_key_id": "bf95cdbf3fea4f96c0c0ed6cffe88a6413e91cec",
+  "project_id": "iam-testbucket-reqsign-project",
+  "private_key_id": "abcdefabcdef4f96c0c0ed6cffe88a6413e91cec",
   "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDMXQUceY0V5Id3\nhT4Xu/eUOkj7vYMxmcM7u03g/R5d1Jj+5WdpeLu/Kjh2EhXuCfodCSawEoU1O66h\nfL9A2EMefHRE3tPMYDCYJgUqes/6of4QcSJKev29blbryKrNfQEp4xzRX9oY68bs\nRNVoDN/tIKovZle7VvOPjK83HeTv/R9l93dbKS1lTIYrNI86aRhvvnfbDZGTq/iI\nMHreTD8ICc06qsH774uVMBhTH3bxRQ8NTrZP70PS8RfCCTVNwiwSPE146aU6XUWU\nh+29rqbMNHHQsWLCLeLTY565kD+a2DtNIU0H89wPxnirDouZBYwCjtivvlE0mN5y\nj1qkPrwfAgMBAAECggEBAMO6k5qiEC5XoicmxkGVFZox+JSi/XQUAJjE2+IQi3Ty\nmVYIAPNTXv3IQitTRw2lIJeOnC8mjc5eSvL/t20zs5UPPYx4ngGwXtpaD7iPx4IU\nhHDa6izLfxpfA4DvwCbvAp5Llt4xH4Gez/aaNophSlaiYlzjeENFFCD4bRgs2Ye+\n/pyF0akNf7RO2PXC0u0KbP3rf/tqY+tGnNg7Ykx3+4yEetwFW2RgL3IlLU4PM2Xg\nRrjdiLHNOjS1VXCBMaEYuoP1HFCR+JzyBdidD++/kTSHVCab9Dz4HemyKxr8gpYK\nZUREirN8GFZwVt+SysWzIh788adhhy7Tscyy6SoQ2AECgYEA+76McDcxlEGTkRuO\nXh/dEeFDnSGEqOC3HfYJbzlo+K5bD9ged3DtwSN+bxDizHtcQnhqMPOhrD0tgiCn\nmNsEPXAhj3eoRd050R6THEXwE5Az84SR9gvm27Q8JoAUWXWIkrpVKPwDDjq7XoIF\nY1lTld84UGwg8Hgux05KcMZROd8CgYEAz9FszBaX1OgmRcOklxmDgFsWsdiepFpL\nrTj6oNpbHiJYYDJ0DQgvty8dI+1aWfqgHh1TczjYRx3Cf77qUGpYzY/Vkc2lC+fU\naxXz3qmaKIYZH/IA5+EZshXjMSwTTaGzpmzoqXZ57J9uwmQeUsLeXnlZd1habk7O\nD3CZhuK3RcECgYBGWUdRjHr0XSbpo/Oy5eCXQIXugRFbSACkBL86L6bf54lW8iQB\naLNoB40raGKYldiAUroKF+sUALyY4pszIfEbYhxexSdm7p1bjNm7Suf974w0/tTz\nFvxaZRFyCNSm8ytJJXzqyRHphgwaKudqjenHtes8vhquWEdqNryiqyjDrQKBgCV7\nNBArEv9HT3/NpWXLKDiCNTmmRBaIYpW/bRSNzVlGAIJ5Fw0yqMh1KuBL8ru/xBkq\nWN6zJe7No0K/ACu4woNwqag+WsIm8dzOfMlv9WnRpb5pO1iW9Ld10yAPPvwFag1e\nHyhRQfQ3XRaaUA3FL64CXOx1dvnmJKwMNuRpB30BAoGBAJ+DhBf9CM6ndMBJaOZa\nD8Let93+NYu/iJEn2whzN1cGBcnsOw9uAWiOkFUOuNqYVzSih11vLvUIw9Q9LKnI\n8MLsFLjvierQ1h+V1mxhNO8bEv9tTO+O8h1GMNmCy4S0wZjfsbrJzPL+pKrpgEJS\nqjDDLD9IP7jvoKHSODDsecNq\n-----END PRIVATE KEY-----\n",
-  "client_email": "testbucket-reqsign-account@noted-throne-361708.iam.gserviceaccount.com",
-  "client_id": "101897973319603871966",
+  "client_email": "testbucket-reqsign-account@iam-testbucket-reqsign-project.iam.gserviceaccount.com",
+  "client_id": "101000000000000000000",
   "auth_uri": "https://accounts.google.com/o/oauth2/auth",
   "token_uri": "https://oauth2.googleapis.com/token",
   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/testbucket-reqsign-account%40noted-throne-361708.iam.gserviceaccount.com"
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/testbucket-reqsign-account%iam-testbucket-reqsign-project.iam.gserviceaccount.iam.gserviceaccount.com"
 }

--- a/testdata/services/google/testbucket_credential.json
+++ b/testdata/services/google/testbucket_credential.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "noted-throne-361708",
+  "private_key_id": "bf95cdbf3fea4f96c0c0ed6cffe88a6413e91cec",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDMXQUceY0V5Id3\nhT4Xu/eUOkj7vYMxmcM7u03g/R5d1Jj+5WdpeLu/Kjh2EhXuCfodCSawEoU1O66h\nfL9A2EMefHRE3tPMYDCYJgUqes/6of4QcSJKev29blbryKrNfQEp4xzRX9oY68bs\nRNVoDN/tIKovZle7VvOPjK83HeTv/R9l93dbKS1lTIYrNI86aRhvvnfbDZGTq/iI\nMHreTD8ICc06qsH774uVMBhTH3bxRQ8NTrZP70PS8RfCCTVNwiwSPE146aU6XUWU\nh+29rqbMNHHQsWLCLeLTY565kD+a2DtNIU0H89wPxnirDouZBYwCjtivvlE0mN5y\nj1qkPrwfAgMBAAECggEBAMO6k5qiEC5XoicmxkGVFZox+JSi/XQUAJjE2+IQi3Ty\nmVYIAPNTXv3IQitTRw2lIJeOnC8mjc5eSvL/t20zs5UPPYx4ngGwXtpaD7iPx4IU\nhHDa6izLfxpfA4DvwCbvAp5Llt4xH4Gez/aaNophSlaiYlzjeENFFCD4bRgs2Ye+\n/pyF0akNf7RO2PXC0u0KbP3rf/tqY+tGnNg7Ykx3+4yEetwFW2RgL3IlLU4PM2Xg\nRrjdiLHNOjS1VXCBMaEYuoP1HFCR+JzyBdidD++/kTSHVCab9Dz4HemyKxr8gpYK\nZUREirN8GFZwVt+SysWzIh788adhhy7Tscyy6SoQ2AECgYEA+76McDcxlEGTkRuO\nXh/dEeFDnSGEqOC3HfYJbzlo+K5bD9ged3DtwSN+bxDizHtcQnhqMPOhrD0tgiCn\nmNsEPXAhj3eoRd050R6THEXwE5Az84SR9gvm27Q8JoAUWXWIkrpVKPwDDjq7XoIF\nY1lTld84UGwg8Hgux05KcMZROd8CgYEAz9FszBaX1OgmRcOklxmDgFsWsdiepFpL\nrTj6oNpbHiJYYDJ0DQgvty8dI+1aWfqgHh1TczjYRx3Cf77qUGpYzY/Vkc2lC+fU\naxXz3qmaKIYZH/IA5+EZshXjMSwTTaGzpmzoqXZ57J9uwmQeUsLeXnlZd1habk7O\nD3CZhuK3RcECgYBGWUdRjHr0XSbpo/Oy5eCXQIXugRFbSACkBL86L6bf54lW8iQB\naLNoB40raGKYldiAUroKF+sUALyY4pszIfEbYhxexSdm7p1bjNm7Suf974w0/tTz\nFvxaZRFyCNSm8ytJJXzqyRHphgwaKudqjenHtes8vhquWEdqNryiqyjDrQKBgCV7\nNBArEv9HT3/NpWXLKDiCNTmmRBaIYpW/bRSNzVlGAIJ5Fw0yqMh1KuBL8ru/xBkq\nWN6zJe7No0K/ACu4woNwqag+WsIm8dzOfMlv9WnRpb5pO1iW9Ld10yAPPvwFag1e\nHyhRQfQ3XRaaUA3FL64CXOx1dvnmJKwMNuRpB30BAoGBAJ+DhBf9CM6ndMBJaOZa\nD8Let93+NYu/iJEn2whzN1cGBcnsOw9uAWiOkFUOuNqYVzSih11vLvUIw9Q9LKnI\n8MLsFLjvierQ1h+V1mxhNO8bEv9tTO+O8h1GMNmCy4S0wZjfsbrJzPL+pKrpgEJS\nqjDDLD9IP7jvoKHSODDsecNq\n-----END PRIVATE KEY-----\n",
+  "client_email": "testbucket-reqsign-account@noted-throne-361708.iam.gserviceaccount.com",
+  "client_id": "101897973319603871966",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/testbucket-reqsign-account%40noted-throne-361708.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
I've started again from scratch, duplicating everything I needed for google v4 signing. 

There is a "second" builder now, and I am not sure if we want to keep that or not. 

I left in the header signing method, but I can remove it if you don't want it for now.
I believe we could just as well replace the current Google implementation with this one, I am not aware of any drawbacks and it would get rid of the more complicated token procedure.

Still need to add some tests.

