### PR TITLE
🍋 feat: support azure imds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,11 @@ services-aws = [
   "dep:quick-xml",
   "dep:rust-ini",
 ]
-services-azblob = ["dep:serde", "dep:serde_json"]
+services-azblob = [
+  "dep:serde",
+  "dep:serde_json",
+  "dep:reqwest",
+]
 services-google = [
   "dep:reqwest",
   "dep:serde",

--- a/src/azure/storage/config.rs
+++ b/src/azure/storage/config.rs
@@ -1,5 +1,3 @@
-use crate::azure::storage::imds_credential::ImdsCredential;
-
 /// Config carries all the configuration for Azure Storage services.
 #[derive(Clone, Default)]
 #[cfg_attr(test, derive(Debug))]
@@ -16,6 +14,24 @@ pub struct Config {
     ///
     /// - this field if it's `is_some`
     pub sas_token: Option<String>,
-    /// Will load credential from IMDS if it's `is_some`.
-    pub imds_credential: Option<ImdsCredential>,
+    /// Specifies the object id associated with a user assigned managed service identity resource
+    ///
+    /// The values of client_id and msi_res_id are discarded
+    pub imds_object_id: Option<String>,
+    /// Specifies the application id (client id) associated with a user assigned managed service identity resource
+    ///
+    /// The values of object_id and msi_res_id are discarded
+    pub imds_client_id: Option<String>,
+    /// Specifies the ARM resource id of the user assigned managed service identity resource
+    ///
+    /// The values of object_id and client_id are discarded
+    pub imds_msi_res_id: Option<String>,
+    /// Specifies the header that should be used to retrieve the access token.
+    ///
+    /// This header mitigates server-side request forgery (SSRF) attacks.
+    pub imds_msi_secret: Option<String>,
+    /// Specifies the endpoint from which the identity should be retrieved.
+    ///
+    /// If not specified, the default endpoint of `http://169.254.169.254/metadata/identity/oauth2/token` will be used.
+    pub imds_endpoint: Option<String>,
 }

--- a/src/azure/storage/config.rs
+++ b/src/azure/storage/config.rs
@@ -17,21 +17,31 @@ pub struct Config {
     /// Specifies the object id associated with a user assigned managed service identity resource
     ///
     /// The values of client_id and msi_res_id are discarded
-    pub imds_object_id: Option<String>,
+    ///
+    /// This is part of use AAD(Azure Active Directory) authenticate on Azure VM
+    pub object_id: Option<String>,
     /// Specifies the application id (client id) associated with a user assigned managed service identity resource
     ///
     /// The values of object_id and msi_res_id are discarded
-    pub imds_client_id: Option<String>,
+    ///
+    /// This is part of use AAD(Azure Active Directory) authenticate on Azure VM
+    pub client_id: Option<String>,
     /// Specifies the ARM resource id of the user assigned managed service identity resource
     ///
     /// The values of object_id and client_id are discarded
-    pub imds_msi_res_id: Option<String>,
+    ///
+    /// This is part of use AAD(Azure Active Directory) authenticate on Azure VM
+    pub msi_res_id: Option<String>,
     /// Specifies the header that should be used to retrieve the access token.
     ///
     /// This header mitigates server-side request forgery (SSRF) attacks.
-    pub imds_msi_secret: Option<String>,
+    ///
+    /// This is part of use AAD(Azure Active Directory) authenticate on Azure VM
+    pub msi_secret: Option<String>,
     /// Specifies the endpoint from which the identity should be retrieved.
     ///
     /// If not specified, the default endpoint of `http://169.254.169.254/metadata/identity/oauth2/token` will be used.
-    pub imds_endpoint: Option<String>,
+    ///
+    /// This is part of use AAD(Azure Active Directory) authenticate on Azure VM
+    pub endpoint: Option<String>,
 }

--- a/src/azure/storage/config.rs
+++ b/src/azure/storage/config.rs
@@ -1,3 +1,5 @@
+use crate::azure::storage::imds_credential::ImdsCredential;
+
 /// Config carries all the configuration for Azure Storage services.
 #[derive(Clone, Default)]
 #[cfg_attr(test, derive(Debug))]
@@ -14,16 +16,6 @@ pub struct Config {
     ///
     /// - this field if it's `is_some`
     pub sas_token: Option<String>,
-    /// `tenant_id` will be used to acquire an access token from Azure Instance Metadata Service (IMDS)
-    ///
-    /// - this field if it's `is_some`
-    pub tenant_id: Option<String>,
-    /// `client_id` will be used to acquire an access token from Azure Instance Metadata Service (IMDS)
-    ///
-    /// - this field if it's `is_some`
-    pub client_secret: Option<String>,
-    /// `client_secret` will be used to acquire an access token from Azure Instance Metadata Service (IMDS)
-    ///
-    /// - this field if it's `is_some`
-    pub client_id: Option<String>,
+    /// Will load credential from IMDS if it's `is_some`.
+    pub imds_credential: Option<ImdsCredential>,
 }

--- a/src/azure/storage/config.rs
+++ b/src/azure/storage/config.rs
@@ -14,4 +14,16 @@ pub struct Config {
     ///
     /// - this field if it's `is_some`
     pub sas_token: Option<String>,
+    /// `tenant_id` will be used to acquire an access token from Azure Instance Metadata Service (IMDS)
+    ///
+    /// - this field if it's `is_some`
+    pub tenant_id: Option<String>,
+    /// `client_id` will be used to acquire an access token from Azure Instance Metadata Service (IMDS)
+    ///
+    /// - this field if it's `is_some`
+    pub client_secret: Option<String>,
+    /// `client_secret` will be used to acquire an access token from Azure Instance Metadata Service (IMDS)
+    ///
+    /// - this field if it's `is_some`
+    pub client_id: Option<String>,
 }

--- a/src/azure/storage/imds_credential.rs
+++ b/src/azure/storage/imds_credential.rs
@@ -132,6 +132,7 @@ impl ImdsCredential {
         }
 
         let token: AccessToken = serde_json::from_str(&rsp_body)?;
+        println!("token = {:?}", token);
 
         Ok(token)
     }
@@ -143,8 +144,7 @@ impl ImdsCredential {
 #[allow(unused)]
 pub struct AccessToken {
     pub access_token: String,
-    // #[serde(deserialize_with = "expires_on_string")]
-    // pub expires_on: OffsetDateTime,
+    pub expires_on: String,
     pub token_type: String,
     pub resource: String,
 }

--- a/src/azure/storage/imds_credential.rs
+++ b/src/azure/storage/imds_credential.rs
@@ -1,0 +1,155 @@
+use async_trait::async_trait;
+use http::{HeaderValue, Method, Request};
+use reqwest::{Client, Url};
+use serde::{de::Deserializer, Deserialize};
+use std::str;
+
+const MSI_API_VERSION: &str = "2019-08-01";
+
+/// Attempts authentication using a managed identity that has been assigned to the deployment environment.
+///
+/// This authentication type works in Azure VMs, App Service and Azure Functions applications, as well as the Azure Cloud Shell
+///
+/// Built up from docs at [https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol](https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol)
+pub struct ImdsManagedIdentityCredential {
+    endpoint: Option<String>,
+    secret: Option<String>,
+    object_id: Option<String>,
+    client_id: Option<String>,
+    msi_res_id: Option<String>,
+}
+
+impl Default for ImdsManagedIdentityCredential {
+    /// Creates an instance of the `TransportOptions` with the default parameters.
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ImdsManagedIdentityCredential {
+    /// Creates a new `ImdsManagedIdentityCredential` with the specified parameters.
+    pub fn new() -> Self {
+        Self {
+            object_id: None,
+            client_id: None,
+            msi_res_id: None,
+            secret: None,
+            endpoint: None,
+        }
+    }
+
+    /// Specifies the endpoint from which the identity should be retrieved.
+    pub fn with_endpoint<A>(mut self, endpoint: A) -> Self
+    where
+        A: Into<String>,
+    {
+        self.endpoint = Some(endpoint.into());
+        self
+    }
+
+    /// Specifies the secret associated with a user assigned managed service identity resource that should be used to retrieve the access token.
+    pub fn with_secret<A>(mut self, secret: A) -> Self
+    where
+        A: Into<String>,
+    {
+        self.secret = Some(secret.into());
+        self
+    }
+
+    /// Specifies the object id associated with a user assigned managed service identity resource that should be used to retrieve the access token.
+    ///
+    /// The values of client_id and msi_res_id are discarded, as only one id parameter may be set when getting a token.
+    pub fn with_object_id<A>(mut self, object_id: A) -> Self
+    where
+        A: Into<String>,
+    {
+        self.object_id = Some(object_id.into());
+        self.client_id = None;
+        self.msi_res_id = None;
+        self
+    }
+
+    /// Specifies the application id (client id) associated with a user assigned managed service identity resource that should be used to retrieve the access token.
+    ///
+    /// The values of object_id and msi_res_id are discarded, as only one id parameter may be set when getting a token.
+    pub fn with_client_id<A>(mut self, client_id: A) -> Self
+    where
+        A: Into<String>,
+    {
+        self.client_id = Some(client_id.into());
+        self.object_id = None;
+        self.msi_res_id = None;
+        self
+    }
+
+    /// Specifies the ARM resource id of the user assigned managed service identity resource that should be used to retrieve the access token.
+    ///
+    /// The values of object_id and client_id are discarded, as only one id parameter may be set when getting a token.
+    pub fn with_identity<A>(mut self, msi_res_id: A) -> Self
+    where
+        A: Into<String>,
+    {
+        self.msi_res_id = Some(msi_res_id.into());
+        self.object_id = None;
+        self.client_id = None;
+        self
+    }
+
+    pub async fn get_token(&self, resource: &str) -> anyhow::Result<MsiTokenResponse> {
+        let msi_endpoint = self
+            .endpoint
+            .unwrap_or_else(|_| "http://169.254.169.254/metadata/identity/oauth2/token".to_owned());
+
+        let mut query_items = vec![("api-version", MSI_API_VERSION), ("resource", resource)];
+
+        match (
+            self.object_id.as_ref(),
+            self.client_id.as_ref(),
+            self.msi_res_id.as_ref(),
+        ) {
+            (Some(object_id), None, None) => query_items.push(("object_id", object_id)),
+            (None, Some(client_id), None) => query_items.push(("client_id", client_id)),
+            (None, None, Some(msi_res_id)) => query_items.push(("msi_res_id", msi_res_id)),
+            _ => (),
+        }
+
+        let url = Url::parse_with_params(&msi_endpoint, &query_items)?;
+        let mut builder = Request::builder();
+        builder = builder.method(Method::Get);
+        builder = builder.uri(url);
+        let mut req = builder.body("")?;
+
+        req.headers_mut()
+            .insert("metadata", HeaderValue::from_static("true"));
+
+        if let Some(secret) = &self.secret {
+            req.headers_mut()
+                .insert("x-identity-header", HeaderValue::from_str(secret)?);
+        };
+
+        let res = Client::new().execute(req.try_into()?).await?;
+        let rsp_status = res.status();
+        let rsp_body = res.into_body().collect().await?;
+
+        if !rsp_status.is_success() {
+            panic!("Error getting MSI token: {}", res.text()?);
+        }
+
+        let x: MsiTokenResponse = serde_json::from_slice(&rsp_body)?;
+
+        Ok(x)
+    }
+}
+
+// NOTE: expires_on is a String version of unix epoch time, not an integer.
+// https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=dotnet#rest-protocol-examples
+#[derive(Debug, Clone, Deserialize)]
+#[allow(unused)]
+struct MsiTokenResponse {
+    pub access_token: String,
+    // #[serde(deserialize_with = "expires_on_string")]
+    // pub expires_on: OffsetDateTime,
+    pub token_type: String,
+    pub resource: String,
+}

--- a/src/azure/storage/imds_credential.rs
+++ b/src/azure/storage/imds_credential.rs
@@ -3,135 +3,55 @@ use reqwest::{Client, Url};
 use serde::Deserialize;
 use std::str;
 
+use super::config::Config;
+
 const MSI_API_VERSION: &str = "2019-08-01";
 const MSI_ENDPOINT: &str = "http://169.254.169.254/metadata/identity/oauth2/token";
 
-/// Attempts authentication using a managed identity that has been assigned to the deployment environment.
+/// Gets an access token for the specified resource and configuration.
 ///
-/// This authentication type works in Azure VMs, App Service and Azure Functions applications, as well as the Azure Cloud Shell
-///
-/// Built up from docs at <https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol>
-#[derive(Clone, Debug, Default)]
-pub struct ImdsCredential {
-    object_id: Option<String>,
-    client_id: Option<String>,
-    msi_res_id: Option<String>,
-    msi_secret: Option<String>,
-    endpoint: Option<String>,
-}
+/// See <https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal,http#using-the-rest-protocol>
+pub async fn get_access_token(resource: &str, config: &Config) -> anyhow::Result<AccessToken> {
+    let endpoint = config.imds_endpoint.as_deref().unwrap_or(MSI_ENDPOINT);
+    let mut query_items = vec![("api-version", MSI_API_VERSION), ("resource", resource)];
 
-impl ImdsCredential {
-    /// Creates a new instance of the ImdsCredential with default parameters.
-    pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
-    }
+    match (
+        config.imds_object_id.as_ref(),
+        config.imds_client_id.as_ref(),
+        config.imds_msi_res_id.as_ref(),
+    ) {
+        (Some(object_id), None, None) => query_items.push(("object_id", object_id)),
+        (None, Some(client_id), None) => query_items.push(("client_id", client_id)),
+        (None, None, Some(msi_res_id)) => query_items.push(("msi_res_id", msi_res_id)),
+        // Only one of the object_id, client_id, or msi_res_id can be specified, if you specify both, will ignore all.
+        _ => (),
+    };
 
-    /// Specifies the endpoint from which the identity should be retrieved.
-    ///
-    /// If not specified, the default endpoint of `http://169.254.169.254/metadata/identity/oauth2/token` will be used.
-    pub fn with_endpoint<A>(mut self, endpoint: A) -> Self
-    where
-        A: Into<String>,
-    {
-        self.endpoint = Some(endpoint.into());
-        self
-    }
+    let url = Url::parse_with_params(endpoint, &query_items)?;
+    let mut req = Request::builder()
+        .method(Method::GET)
+        .uri(url.to_string())
+        .body("")?;
 
-    /// Specifies the header that should be used to retrieve the access token.
-    ///
-    /// This header mitigates server-side request forgery (SSRF) attacks.
-    pub fn with_msi_secret<A>(mut self, msi_secret: A) -> Self
-    where
-        A: Into<String>,
-    {
-        self.msi_secret = Some(msi_secret.into());
-        self
-    }
+    req.headers_mut()
+        .insert("metadata", HeaderValue::from_static("true"));
 
-    /// Specifies the object id associated with a user assigned managed service identity resource that should be used to retrieve the access token.
-    ///
-    /// The values of client_id and msi_res_id are discarded, as only one id parameter may be set when getting a token.
-    pub fn with_object_id<A>(mut self, object_id: A) -> Self
-    where
-        A: Into<String>,
-    {
-        self.object_id = Some(object_id.into());
-        self.client_id = None;
-        self.msi_res_id = None;
-        self
-    }
-
-    /// Specifies the application id (client id) associated with a user assigned managed service identity resource that should be used to retrieve the access token.
-    ///
-    /// The values of object_id and msi_res_id are discarded, as only one id parameter may be set when getting a token.
-    pub fn with_client_id<A>(mut self, client_id: A) -> Self
-    where
-        A: Into<String>,
-    {
-        self.client_id = Some(client_id.into());
-        self.object_id = None;
-        self.msi_res_id = None;
-        self
-    }
-
-    /// Specifies the ARM resource id of the user assigned managed service identity resource that should be used to retrieve the access token.
-    ///
-    /// The values of object_id and client_id are discarded, as only one id parameter may be set when getting a token.
-    pub fn with_identity<A>(mut self, msi_res_id: A) -> Self
-    where
-        A: Into<String>,
-    {
-        self.msi_res_id = Some(msi_res_id.into());
-        self.object_id = None;
-        self.client_id = None;
-        self
-    }
-
-    /// Gets an access token for the specified resource.
-    pub async fn get_token(&self, resource: &str) -> anyhow::Result<AccessToken> {
-        let endpoint = self.endpoint.as_deref().unwrap_or(MSI_ENDPOINT);
-        let mut query_items = vec![("api-version", MSI_API_VERSION), ("resource", resource)];
-
-        match (
-            self.object_id.as_ref(),
-            self.client_id.as_ref(),
-            self.msi_res_id.as_ref(),
-        ) {
-            (Some(object_id), None, None) => query_items.push(("object_id", object_id)),
-            (None, Some(client_id), None) => query_items.push(("client_id", client_id)),
-            (None, None, Some(msi_res_id)) => query_items.push(("msi_res_id", msi_res_id)),
-            _ => (),
-        }
-
-        let url = Url::parse_with_params(endpoint, &query_items)?;
-        let mut req = Request::builder()
-            .method(Method::GET)
-            .uri(url.to_string())
-            .body("")?;
-
+    if let Some(secret) = &config.imds_msi_secret {
         req.headers_mut()
-            .insert("metadata", HeaderValue::from_static("true"));
+            .insert("x-identity-header", HeaderValue::from_str(secret)?);
+    };
 
-        if let Some(secret) = &self.msi_secret {
-            req.headers_mut()
-                .insert("x-identity-header", HeaderValue::from_str(secret)?);
-        };
+    let res = Client::new().execute(req.try_into()?).await?;
+    let rsp_status = res.status();
+    let rsp_body = res.text().await?;
 
-        let res = Client::new().execute(req.try_into()?).await?;
-        let rsp_status = res.status();
-        let rsp_body = res.text().await?;
-
-        if !rsp_status.is_success() {
-            return Err(anyhow::anyhow!("Failed to get token from IMDS endpoint"));
-        }
-
-        let token: AccessToken = serde_json::from_str(&rsp_body)?;
-        println!("token = {:?}", token);
-
-        Ok(token)
+    if !rsp_status.is_success() {
+        return Err(anyhow::anyhow!("Failed to get token from IMDS endpoint"));
     }
+
+    let token: AccessToken = serde_json::from_str(&rsp_body)?;
+
+    Ok(token)
 }
 
 // NOTE: expires_on is a String version of unix epoch time, not an integer.

--- a/src/azure/storage/imds_credential.rs
+++ b/src/azure/storage/imds_credential.rs
@@ -10,8 +10,8 @@ const MSI_ENDPOINT: &str = "http://169.254.169.254/metadata/identity/oauth2/toke
 ///
 /// This authentication type works in Azure VMs, App Service and Azure Functions applications, as well as the Azure Cloud Shell
 ///
-/// Built up from docs at [https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol](https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol)
-#[derive(Clone, Debug)]
+/// Built up from docs at <https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol>
+#[derive(Clone, Debug, Default)]
 pub struct ImdsCredential {
     object_id: Option<String>,
     client_id: Option<String>,
@@ -20,21 +20,11 @@ pub struct ImdsCredential {
     endpoint: Option<String>,
 }
 
-impl Default for ImdsCredential {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ImdsCredential {
     /// Creates a new instance of the ImdsCredential with default parameters.
     pub fn new() -> Self {
         Self {
-            object_id: None,
-            client_id: None,
-            msi_res_id: None,
-            msi_secret: None,
-            endpoint: None,
+            ..Default::default()
         }
     }
 

--- a/src/azure/storage/imds_credential.rs
+++ b/src/azure/storage/imds_credential.rs
@@ -11,7 +11,7 @@ const MSI_ENDPOINT: &str = "http://169.254.169.254/metadata/identity/oauth2/toke
 /// This authentication type works in Azure VMs, App Service and Azure Functions applications, as well as the Azure Cloud Shell
 ///
 /// Built up from docs at [https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol](https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol)
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ImdsCredential {
     object_id: Option<String>,
     client_id: Option<String>,
@@ -93,6 +93,7 @@ impl ImdsCredential {
         self
     }
 
+    /// Gets an access token for the specified resource.
     pub async fn get_token(&self, resource: &str) -> anyhow::Result<AccessToken> {
         let endpoint = self.endpoint.as_deref().unwrap_or(MSI_ENDPOINT);
         let mut query_items = vec![("api-version", MSI_API_VERSION), ("resource", resource)];

--- a/src/azure/storage/imds_credential.rs
+++ b/src/azure/storage/imds_credential.rs
@@ -20,6 +20,12 @@ pub struct ImdsCredential {
     endpoint: Option<String>,
 }
 
+impl Default for ImdsCredential {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ImdsCredential {
     /// Creates a new instance of the ImdsCredential with default parameters.
     pub fn new() -> Self {
@@ -109,7 +115,7 @@ impl ImdsCredential {
             _ => (),
         }
 
-        let url = Url::parse_with_params(&endpoint, &query_items)?;
+        let url = Url::parse_with_params(endpoint, &query_items)?;
         let mut req = Request::builder()
             .method(Method::GET)
             .uri(url.to_string())

--- a/src/azure/storage/imds_credential.rs
+++ b/src/azure/storage/imds_credential.rs
@@ -12,13 +12,13 @@ const MSI_ENDPOINT: &str = "http://169.254.169.254/metadata/identity/oauth2/toke
 ///
 /// See <https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal,http#using-the-rest-protocol>
 pub async fn get_access_token(resource: &str, config: &Config) -> anyhow::Result<AccessToken> {
-    let endpoint = config.imds_endpoint.as_deref().unwrap_or(MSI_ENDPOINT);
+    let endpoint = config.endpoint.as_deref().unwrap_or(MSI_ENDPOINT);
     let mut query_items = vec![("api-version", MSI_API_VERSION), ("resource", resource)];
 
     match (
-        config.imds_object_id.as_ref(),
-        config.imds_client_id.as_ref(),
-        config.imds_msi_res_id.as_ref(),
+        config.object_id.as_ref(),
+        config.client_id.as_ref(),
+        config.msi_res_id.as_ref(),
     ) {
         (Some(object_id), None, None) => query_items.push(("object_id", object_id)),
         (None, Some(client_id), None) => query_items.push(("client_id", client_id)),
@@ -36,7 +36,7 @@ pub async fn get_access_token(resource: &str, config: &Config) -> anyhow::Result
     req.headers_mut()
         .insert("metadata", HeaderValue::from_static("true"));
 
-    if let Some(secret) = &config.imds_msi_secret {
+    if let Some(secret) = &config.msi_secret {
         req.headers_mut()
             .insert("x-identity-header", HeaderValue::from_str(secret)?);
     };

--- a/src/azure/storage/loader.rs
+++ b/src/azure/storage/loader.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use crate::azure::storage::imds_credential::ImdsManagedIdentityCredential;
 use anyhow::Result;
 
 use super::config::Config;
@@ -59,5 +60,11 @@ impl Loader {
         }
 
         Ok(None)
+    }
+
+    async fn load_access_token_via_imds(&self) -> Result<Option<String>> {
+        let token = ImdsManagedIdentityCredential::new().get_token("").await?;
+
+        Ok(Some(token.access_token))
     }
 }

--- a/src/azure/storage/loader.rs
+++ b/src/azure/storage/loader.rs
@@ -45,7 +45,10 @@ impl Loader {
             return Ok(Some(cred));
         }
 
-        Ok(None)
+        // try to load credential using AAD(Azure Active Directory) authenticate on Azure VM
+        // we may get an error if not running on Azure VM
+        // see https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal,http#using-the-rest-protocol
+        self.load_via_imds().await
     }
 
     async fn load_via_config(&self) -> Result<Option<Credential>> {
@@ -59,10 +62,7 @@ impl Loader {
             return Ok(Some(cred));
         }
 
-        // try to load credential using AAD(Azure Active Directory) authenticate on Azure VM
-        // we may get an error if not running on Azure VM
-        // see https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal,http#using-the-rest-protocol
-        self.load_via_imds().await
+        Ok(None)
     }
 
     async fn load_via_imds(&self) -> Result<Option<Credential>> {

--- a/src/azure/storage/loader.rs
+++ b/src/azure/storage/loader.rs
@@ -67,7 +67,7 @@ impl Loader {
     }
 
     async fn load_via_imds(&self, imds: &ImdsCredential) -> Result<Option<Credential>> {
-        let token = imds.get_token("").await?;
+        let token = imds.get_token("https://storage.azure.com/").await?;
 
         Ok(Some(Credential::BearerToken(token.access_token)))
     }

--- a/src/azure/storage/loader.rs
+++ b/src/azure/storage/loader.rs
@@ -40,24 +40,6 @@ impl Loader {
         Ok(cred)
     }
 
-    /// Load credential with IMDS.
-    pub async fn load_with_imds(&self) -> Result<Option<Credential>> {
-        // Return cached credential if it's valid.
-        if let Some(cred) = self.credential.lock().expect("lock poisoned").clone() {
-            return Ok(Some(cred));
-        }
-
-        let token =
-            imds_credential::get_access_token("https://storage.azure.com/", &self.config).await?;
-
-        let cred = Some(Credential::BearerToken(token.access_token));
-
-        let mut lock = self.credential.lock().expect("lock poisoned");
-        *lock = cred.clone();
-
-        Ok(cred)
-    }
-
     async fn load_inner(&self) -> Result<Option<Credential>> {
         if let Some(cred) = self.load_via_config().await? {
             return Ok(Some(cred));
@@ -77,6 +59,17 @@ impl Loader {
             return Ok(Some(cred));
         }
 
-        Ok(None)
+        // try to load credential using AAD(Azure Active Directory) authenticate on Azure VM
+        // we may get an error if not running on Azure VM
+        // see https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal,http#using-the-rest-protocol
+        self.load_via_imds().await
+    }
+
+    async fn load_via_imds(&self) -> Result<Option<Credential>> {
+        let token =
+            imds_credential::get_access_token("https://storage.azure.com/", &self.config).await?;
+        let cred = Some(Credential::BearerToken(token.access_token));
+
+        Ok(cred)
     }
 }

--- a/src/azure/storage/mod.rs
+++ b/src/azure/storage/mod.rs
@@ -14,8 +14,6 @@ pub use credential::Credential as AzureStorageCredential;
 
 mod imds_credential;
 
-pub use imds_credential::ImdsCredential as AzureStorageImdsCredential;
-
 mod loader;
 
 pub use loader::Loader as AzureStorageLoader;

--- a/src/azure/storage/mod.rs
+++ b/src/azure/storage/mod.rs
@@ -9,6 +9,7 @@ mod config;
 pub use config::Config as AzureStorageConfig;
 
 mod credential;
+mod imds_credential;
 
 pub use credential::Credential as AzureStorageCredential;
 

--- a/src/azure/storage/mod.rs
+++ b/src/azure/storage/mod.rs
@@ -9,9 +9,12 @@ mod config;
 pub use config::Config as AzureStorageConfig;
 
 mod credential;
-mod imds_credential;
 
 pub use credential::Credential as AzureStorageCredential;
+
+mod imds_credential;
+
+pub use imds_credential::ImdsCredential as AzureStorageImdsCredential;
 
 mod loader;
 

--- a/src/azure/storage/signer.rs
+++ b/src/azure/storage/signer.rs
@@ -72,10 +72,15 @@ impl Signer {
                     return Err(anyhow!("BearerToken can't be used in query string"));
                 }
                 SigningMethod::Header => {
+                    ctx.headers
+                        .insert(X_MS_VERSION, AZURE_VERSION.to_string().parse()?);
+                    if self.omit_service_version {
+                        ctx.headers
+                            .insert(X_MS_DATE, format_http_date(time::now()).parse()?);
+                    }
                     ctx.headers.insert(AUTHORIZATION, {
                         let mut value: HeaderValue = format!("Bearer {}", token).parse()?;
                         value.set_sensitive(true);
-
                         value
                     });
                 }

--- a/tests/azure/storage.rs
+++ b/tests/azure/storage.rs
@@ -10,7 +10,7 @@ use percent_encoding::utf8_percent_encode;
 use percent_encoding::NON_ALPHANUMERIC;
 
 use reqsign::AzureStorageSigner;
-use reqsign::{AzureStorageConfig, AzureStorageImdsCredential, AzureStorageLoader};
+use reqsign::{AzureStorageConfig, AzureStorageLoader};
 use reqwest::Client;
 
 fn init_signer() -> Option<(AzureStorageLoader, AzureStorageSigner)> {
@@ -273,12 +273,11 @@ async fn test_head_blob_with_ldms() -> Result<()> {
     }
 
     let config = AzureStorageConfig {
-        imds_credential: Some(AzureStorageImdsCredential::new()),
         ..Default::default()
     };
     let loader = AzureStorageLoader::new(config);
     let cred = loader
-        .load()
+        .load_with_imds()
         .await
         .expect("load credential must success")
         .unwrap();
@@ -323,12 +322,11 @@ async fn test_can_list_container_blobs_with_ldms() -> Result<()> {
     }
 
     let config = AzureStorageConfig {
-        imds_credential: Some(AzureStorageImdsCredential::new()),
         ..Default::default()
     };
     let loader = AzureStorageLoader::new(config);
     let cred = loader
-        .load()
+        .load_with_imds()
         .await
         .expect("load credential must success")
         .unwrap();

--- a/tests/azure/storage.rs
+++ b/tests/azure/storage.rs
@@ -81,57 +81,6 @@ async fn test_head_blob() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_head_blob_with_ldms() -> Result<()> {
-    let _ = env_logger::builder().is_test(true).try_init();
-    dotenv::from_filename(".env").ok();
-
-    if env::var("REQSIGN_AZURE_STORAGE_TEST").is_err()
-        || env::var("REQSIGN_AZURE_STORAGE_TEST").unwrap() != "on"
-        || env::var("REQSIGN_AZURE_STORAGE_TEST_RUN_ON_IMDS").is_err()
-        || env::var("REQSIGN_AZURE_STORAGE_TEST_RUN_ON_IMDS").unwrap() != "on"
-    {
-        return Ok(());
-    }
-
-    let config = AzureStorageConfig {
-        imds_credential: Some(AzureStorageImdsCredential::new()),
-        ..Default::default()
-    };
-    let loader = AzureStorageLoader::new(config);
-    let cred = loader
-        .load()
-        .await
-        .expect("load credential must success")
-        .unwrap();
-
-    let url =
-        &env::var("REQSIGN_AZURE_STORAGE_URL").expect("env REQSIGN_AZURE_STORAGE_URL must set");
-
-    let mut req = http::Request::builder()
-        .method(http::Method::HEAD)
-        .uri(format!("{}/{}", url, "not_exist_file"))
-        .body("")?;
-
-    AzureStorageSigner::new()
-        .sign(&mut req, &cred)
-        .expect("sign request must success");
-
-    println!("signed request: {:?}", req);
-
-    let client = Client::new();
-    let resp = client
-        .execute(req.try_into()?)
-        .await
-        .expect("request must success");
-
-    let x = resp.text().await.unwrap();
-    println!("got response: {:?}", x);
-
-    // assert_eq!(StatusCode::NOT_FOUND, resp.status());
-    Ok(())
-}
-
-#[tokio::test]
 async fn test_head_object_with_encoded_characters() -> Result<()> {
     let signer = init_signer();
     if signer.is_none() {
@@ -294,6 +243,114 @@ async fn test_can_list_container_blobs() -> Result<()> {
             .unwrap();
         signer
             .sign_query(&mut req, Duration::from_secs(60), &cred)
+            .expect("sign request must success");
+
+        let client = Client::new();
+        let resp = client
+            .execute(req.try_into()?)
+            .await
+            .expect("request must success");
+
+        debug!("got response: {:?}", resp);
+        assert_eq!(StatusCode::OK, resp.status());
+    }
+
+    Ok(())
+}
+
+/// This test must run on azure vm with imds enabled,
+#[tokio::test]
+async fn test_head_blob_with_ldms() -> Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+    dotenv::from_filename(".env").ok();
+
+    if env::var("REQSIGN_AZURE_STORAGE_TEST").is_err()
+        || env::var("REQSIGN_AZURE_STORAGE_TEST").unwrap() != "on"
+        || env::var("REQSIGN_AZURE_STORAGE_CRED").is_err()
+        || env::var("REQSIGN_AZURE_STORAGE_CRED").unwrap() != "imds"
+    {
+        return Ok(());
+    }
+
+    let config = AzureStorageConfig {
+        imds_credential: Some(AzureStorageImdsCredential::new()),
+        ..Default::default()
+    };
+    let loader = AzureStorageLoader::new(config);
+    let cred = loader
+        .load()
+        .await
+        .expect("load credential must success")
+        .unwrap();
+
+    let url =
+        &env::var("REQSIGN_AZURE_STORAGE_URL").expect("env REQSIGN_AZURE_STORAGE_URL must set");
+
+    let mut req = http::Request::builder()
+        .method(http::Method::HEAD)
+        .uri(format!("{}/{}", url, "not_exist_file"))
+        .body("")?;
+
+    AzureStorageSigner::new()
+        .sign(&mut req, &cred)
+        .expect("sign request must success");
+
+    println!("signed request: {:?}", req);
+
+    let client = Client::new();
+    let resp = client
+        .execute(req.try_into()?)
+        .await
+        .expect("request must success");
+
+    assert_eq!(StatusCode::NOT_FOUND, resp.status());
+
+    Ok(())
+}
+
+/// This test must run on azure vm with imds enabled
+#[tokio::test]
+async fn test_can_list_container_blobs_with_ldms() -> Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+    dotenv::from_filename(".env").ok();
+
+    if env::var("REQSIGN_AZURE_STORAGE_TEST").is_err()
+        || env::var("REQSIGN_AZURE_STORAGE_TEST").unwrap() != "on"
+        || env::var("REQSIGN_AZURE_STORAGE_CRED").is_err()
+        || env::var("REQSIGN_AZURE_STORAGE_CRED").unwrap() != "imds"
+    {
+        return Ok(());
+    }
+
+    let config = AzureStorageConfig {
+        imds_credential: Some(AzureStorageImdsCredential::new()),
+        ..Default::default()
+    };
+    let loader = AzureStorageLoader::new(config);
+    let cred = loader
+        .load()
+        .await
+        .expect("load credential must success")
+        .unwrap();
+
+    let url =
+        &env::var("REQSIGN_AZURE_STORAGE_URL").expect("env REQSIGN_AZURE_STORAGE_URL must set");
+
+    for query in [
+        // Without prefix
+        "restype=container&comp=list",
+        // With not encoded prefix
+        "restype=container&comp=list&prefix=test/path/to/dir",
+        // With encoded prefix
+        "restype=container&comp=list&prefix=test%2Fpath%2Fto%2Fdir",
+    ] {
+        let mut builder = http::Request::builder();
+        builder = builder.method(http::Method::GET);
+        builder = builder.uri(format!("{url}?{query}"));
+        let mut req = builder.body("")?;
+
+        AzureStorageSigner::new()
+            .sign(&mut req, &cred)
             .expect("sign request must success");
 
         let client = Client::new();

--- a/tests/azure/storage.rs
+++ b/tests/azure/storage.rs
@@ -277,7 +277,7 @@ async fn test_head_blob_with_ldms() -> Result<()> {
     };
     let loader = AzureStorageLoader::new(config);
     let cred = loader
-        .load_with_imds()
+        .load()
         .await
         .expect("load credential must success")
         .unwrap();
@@ -326,7 +326,7 @@ async fn test_can_list_container_blobs_with_ldms() -> Result<()> {
     };
     let loader = AzureStorageLoader::new(config);
     let cred = loader
-        .load_with_imds()
+        .load()
         .await
         .expect("load credential must success")
         .unwrap();


### PR DESCRIPTION
This is part of #322. We added Azure IMDS support according to this [document](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http), but since IMDS authentication needs to be tested on an Azure VM, we may not be able to test it on CI. Below are my local testing methods.

- Create a new VM on Azure
- Enable Identity
![CleanShot 2023-05-15 at 17 36 33@2x](https://github.com/Xuanwo/reqsign/assets/16079222/82702a79-24b5-4486-9418-42d9956a969a)

- Clone this repository on VM.
- Set .env variable
```
# Azure Storage
REQSIGN_AZURE_STORAGE_TEST=on
REQSIGN_AZURE_STORAGE_CRED=imds
```
- Run test
![CleanShot 2023-05-15 at 17 39 12@2x](https://github.com/Xuanwo/reqsign/assets/16079222/94ab0bcf-af30-4951-836d-b02878c0f72a)
![CleanShot 2023-05-15 at 17 40 02@2x](https://github.com/Xuanwo/reqsign/assets/16079222/9a2986ba-fa97-425a-b6e4-70fc2f608fa7)


From the test results, I think everything is OK. PTAL @Xuanwo 