### PR TITLE
chore(deps): Bump rust-ini to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ quick-xml = { version = "0.31", features = ["serialize"], optional = true }
 rand = "0.8.5"
 reqwest = { version = "0.11", default-features = false, optional = true }
 rsa = { version = "0.9.2" }
-rust-ini = { version = "0.19", optional = true }
+rust-ini = { version = "0.20", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 sha1 = "0.10"


### PR DESCRIPTION
* `rust-ini` 0.20 bumped `ordered-multimap` to 0.7
* `ordered-multimap 0.71` fixed a feature renaming https://github.com/sgodwincs/ordered-multimap-rs/commit/131ab56bbc8e9e4d6df4b7e02c544407c675bc16
* The feature renaming is required for downstream application to bump nightly rust-toolchain. see https://github.com/rust-lang/rust/pull/114656

Please release a minor or patch version (both are OK because the update only breaks nightly toolchain and affect nothing on stable toolchain) after the PR got merged.