### PR TITLE
feat: Add support for `AWS_EC2_METADATA_DISABLED` env var

### DIFF
--- a/src/aws/config.rs
+++ b/src/aws/config.rs
@@ -84,6 +84,11 @@ pub struct Config {
     /// - env value: [`AWS_WEB_IDENTITY_TOKEN_FILE`]
     /// - profile config: `web_identity_token_file`
     pub web_identity_token_file: Option<String>,
+    /// `ec2_metadata_disabled` value will be loaded from:
+    ///
+    /// - this field
+    /// - env value: [`AWS_EC2_METADATA_DISABLED`]
+    pub ec2_metadata_disabled: bool,
 }
 
 impl Default for Config {
@@ -101,6 +106,7 @@ impl Default for Config {
             role_session_name: "reqsign".to_string(),
             external_id: None,
             web_identity_token_file: None,
+            ec2_metadata_disabled: false,
         }
     }
 }
@@ -143,7 +149,9 @@ impl Config {
         if let Some(v) = envs.get(AWS_WEB_IDENTITY_TOKEN_FILE) {
             self.web_identity_token_file = Some(v.to_string());
         }
-
+        if let Some(v) = envs.get(AWS_EC2_METADATA_DISABLED) {
+            self.ec2_metadata_disabled = v == "true";
+        }
         self
     }
 

--- a/src/aws/constants.rs
+++ b/src/aws/constants.rs
@@ -18,6 +18,7 @@ pub const AWS_WEB_IDENTITY_TOKEN_FILE: &str = "AWS_WEB_IDENTITY_TOKEN_FILE";
 pub const AWS_ROLE_ARN: &str = "AWS_ROLE_ARN";
 pub const AWS_ROLE_SESSION_NAME: &str = "AWS_ROLE_SESSION_NAME";
 pub const AWS_STS_REGIONAL_ENDPOINTS: &str = "AWS_STS_REGIONAL_ENDPOINTS";
+pub const AWS_EC2_METADATA_DISABLED: &str = "AWS_EC2_METADATA_DISABLED";
 
 /// AsciiSet for [AWS UriEncode](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)
 ///

--- a/src/aws/credential.rs
+++ b/src/aws/credential.rs
@@ -73,22 +73,21 @@ pub trait CredentialLoad: 'static + Send + Sync {
 pub struct DefaultLoader {
     client: Client,
     config: Config,
-
     credential: Arc<Mutex<Option<Credential>>>,
-
     imds_v2_loader: Option<IMDSv2Loader>,
 }
 
 impl DefaultLoader {
     /// Create a new CredentialLoader
     pub fn new(client: Client, config: Config) -> Self {
+        let imds_v2_loader = config
+            .ec2_metadata_disabled
+            .then(|| IMDSv2Loader::new(client.clone()));
         Self {
-            client: client.clone(),
+            client,
             config,
-
             credential: Arc::default(),
-
-            imds_v2_loader: Some(IMDSv2Loader::new(client)),
+            imds_v2_loader,
         }
     }
 


### PR DESCRIPTION
xref #202 

See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html

Most AWS SDK supports it, for example boto3:

https://github.com/boto/botocore/blob/01dabf4d3dd645dcd921939a057429f0647cd2ec/botocore/utils.py#L396