### PR TITLE
Google: Add support for impersonated service accounts

### DIFF
--- a/src/azure/storage/sas/account_sas.rs
+++ b/src/azure/storage/sas/account_sas.rs
@@ -98,6 +98,10 @@ impl AccountSharedAccessSignature {
     }
 }
 
+fn urlencoded(s: String) -> String {
+    form_urlencoded::byte_serialize(s.as_bytes()).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -122,8 +126,4 @@ mod tests {
 
         assert_eq!(token, "sv=2018-11-09&ss=bqtf&srt=sco&se=2022-03-01T08%3A17%3A34Z&sp=rwdlacu&sig=jgK9nDUT0ntH%2Fp28LPs0jzwxsk91W6hePLPlfrElv4k%3D");
     }
-}
-
-fn urlencoded(s: String) -> String {
-    form_urlencoded::byte_serialize(s.as_bytes()).collect()
 }

--- a/src/google/credential.rs
+++ b/src/google/credential.rs
@@ -1,6 +1,6 @@
 pub mod external_account;
-pub mod service_account;
 pub mod impersonated_service_account;
+pub mod service_account;
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::env;
@@ -284,8 +284,14 @@ V08rl535r74rMilnQ37X1/zaKBYyxpfhnd2XXgoCgTM=
 
                 assert_eq!("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/example-01-iam@example-01.iam.gserviceaccount.com:generateAccessToken", &cred.service_account_impersonation_url);
                 assert_eq!("placeholder_client_id", &cred.source_credentials.client_id);
-                assert_eq!("placeholder_client_secret", &cred.source_credentials.client_secret);
-                assert_eq!("placeholder_refresh_token", &cred.source_credentials.refresh_token);
+                assert_eq!(
+                    "placeholder_client_secret",
+                    &cred.source_credentials.client_secret
+                );
+                assert_eq!(
+                    "placeholder_refresh_token",
+                    &cred.source_credentials.refresh_token
+                );
             },
         );
     }

--- a/src/google/credential.rs
+++ b/src/google/credential.rs
@@ -215,34 +215,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn loader_returns_impersonated_service_account() {
-        temp_env::with_vars(
-            vec![(
-                GOOGLE_APPLICATION_CREDENTIALS,
-                Some(format!(
-                    "{}/testdata/services/google/test_impersonated_service_account.json",
-                    env::current_dir()
-                        .expect("current_dir must exist")
-                        .to_string_lossy()
-                )),
-            )],
-            || {
-                let cred_loader = CredentialLoader::default();
-
-                let cred = cred_loader
-                    .load()
-                    .expect("credentail must be exist")
-                    .unwrap()
-                    .impersonated_service_account
-                    .expect("couldn't deserialize impersonated service account");
-
-                assert_eq!("xxx", &cred.service_account_impersonation_url)
-            },
-        );
-    }
-
-
-    #[test]
     fn loader_returns_service_account() {
         temp_env::with_vars(
             vec![(
@@ -284,6 +256,36 @@ V08rl535r74rMilnQ37X1/zaKBYyxpfhnd2XXgoCgTM=
 ",
                     &cred.private_key
                 );
+            },
+        );
+    }
+
+    #[test]
+    fn loader_returns_impersonated_service_account() {
+        temp_env::with_vars(
+            vec![(
+                GOOGLE_APPLICATION_CREDENTIALS,
+                Some(format!(
+                    "{}/testdata/services/google/test_impersonated_service_account.json",
+                    env::current_dir()
+                        .expect("current_dir must exist")
+                        .to_string_lossy()
+                )),
+            )],
+            || {
+                let cred_loader = CredentialLoader::default();
+
+                let cred = cred_loader
+                    .load()
+                    .expect("credentail must be exist")
+                    .unwrap()
+                    .impersonated_service_account
+                    .expect("couldn't deserialize impersonated service account");
+
+                assert_eq!("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/example-01-iam@example-01.iam.gserviceaccount.com:generateAccessToken", &cred.service_account_impersonation_url);
+                assert_eq!("placeholder_client_id", &cred.source_credentials.client_id);
+                assert_eq!("placeholder_client_secret", &cred.source_credentials.client_secret);
+                assert_eq!("placeholder_refresh_token", &cred.source_credentials.refresh_token);
             },
         );
     }

--- a/src/google/credential.rs
+++ b/src/google/credential.rs
@@ -34,9 +34,9 @@ pub struct Credential {
     pub ty: CredentialType,
 
     #[serde(flatten)]
-    pub(crate) impersonated_service_account: Option<ImpersonatedServiceAccount>,
-    #[serde(flatten)]
     pub(crate) service_account: Option<ServiceAccount>,
+    #[serde(flatten)]
+    pub(crate) impersonated_service_account: Option<ImpersonatedServiceAccount>,
     #[serde(flatten)]
     pub(crate) external_account: Option<ExternalAccount>,
 }

--- a/src/google/credential.rs
+++ b/src/google/credential.rs
@@ -19,6 +19,7 @@ use crate::hash::base64_decode;
 #[derive(Clone, serde::Deserialize)]
 #[cfg_attr(test, derive(Debug))]
 #[serde(rename_all = "snake_case")]
+#[allow(clippy::enum_variant_names)]
 pub enum CredentialType {
     ImpersonatedServiceAccount,
     ExternalAccount,

--- a/src/google/credential/impersonated_service_account.rs
+++ b/src/google/credential/impersonated_service_account.rs
@@ -1,0 +1,21 @@
+//! An impersonated service account.
+
+#[derive(Clone, serde::Deserialize)]
+#[cfg_attr(test, derive(Debug))]
+#[serde(rename_all = "snake_case")]
+pub struct ImpersonatedServiceAccount {
+    pub delegates: Vec<String>,
+    pub service_account_impersonation_url: String,
+    pub source_credentials: SourceCredentials,
+}
+
+#[derive(Clone, serde::Deserialize)]
+#[cfg_attr(test, derive(Debug))]
+pub struct SourceCredentials {
+    pub client_id: String,
+    pub client_secret: String,
+    pub refresh_token: String,
+
+    #[serde(rename = "type")]
+    pub ty: String,
+}

--- a/src/google/token.rs
+++ b/src/google/token.rs
@@ -1,6 +1,6 @@
 mod external_account;
-mod service_account;
 mod impersonated_service_account;
+mod service_account;
 
 use std::fmt::Debug;
 use std::fmt::Formatter;

--- a/src/google/token.rs
+++ b/src/google/token.rs
@@ -1,5 +1,6 @@
 mod external_account;
 mod service_account;
+mod impersonated_service_account;
 
 use std::fmt::Debug;
 use std::fmt::Formatter;
@@ -202,6 +203,10 @@ impl TokenLoader {
         }
 
         if let Some(token) = self.load_via_service_account().await? {
+            return Ok(Some(token));
+        }
+
+        if let Some(token) = self.load_via_impersonated_service_account().await? {
             return Ok(Some(token));
         }
 

--- a/src/google/token/impersonated_service_account.rs
+++ b/src/google/token/impersonated_service_account.rs
@@ -1,0 +1,96 @@
+use std::time::Duration;
+
+use anyhow::bail;
+use anyhow::Result;
+use http::header::CONTENT_TYPE;
+use log::error;
+use serde::Deserialize;
+
+use crate::google::credential::impersonated_service_account::ImpersonatedServiceAccount;
+
+use super::Token;
+use super::TokenLoader;
+
+#[derive(Clone, Deserialize, Default)]
+#[cfg_attr(test, derive(Debug))]
+#[serde(default, rename_all = "camelCase")]
+struct ImpersonatedToken {
+    access_token: String,
+    expire_time: String,
+}
+
+/// The maximum impersonated token lifetime allowed, 1 hour.
+const MAX_LIFETIME: Duration = Duration::from_secs(3600);
+
+impl TokenLoader {
+    pub(super) async fn load_via_impersonated_service_account(&self) -> Result<Option<Token>> {
+        let Some(cred) = self
+            .credential
+            .as_ref()
+            .and_then(|cred| cred.impersonated_service_account.as_ref())
+        else {
+            return Ok(None);
+        };
+
+        let bearer_auth_token = self.generate_bearer_auth_token(cred).await?;
+        self.generate_access_token(cred, bearer_auth_token).await.map(Some)
+    }
+
+    async fn generate_bearer_auth_token(&self, cred: &ImpersonatedServiceAccount) -> Result<Token> {
+        let req = serde_json::json!({
+            "grant_type": "refresh_token",
+            "refresh_token": &cred.source_credentials.refresh_token,
+            "client_id": &cred.source_credentials.client_id,
+            "client_secret": &cred.source_credentials.client_secret,
+        });
+
+        let req = serde_json::to_vec(&req)?;
+
+        let resp = self
+            .client
+            .post("https://oauth2.googleapis.com/token")
+            .header(CONTENT_TYPE, "application/json")
+            .body(req)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            error!("bearer token loader for impersonated service account got unexpected response: {:?}", resp);
+            bail!("bearer token loader for impersonated service account failed: {}", resp.text().await?);
+        }
+
+        let token: Option<Token> = serde_json::from_slice(&resp.bytes().await?)?;
+        let token = token.expect("couldn't parse bearer token response");
+
+        Ok(token)
+    }
+
+    async fn generate_access_token(&self, cred: &ImpersonatedServiceAccount, temp_token: Token) -> Result<Token> {
+        let req = serde_json::json!({
+            "lifetime": format!("{}s", MAX_LIFETIME.as_secs()),
+            "scope": &temp_token.scope.split(" ").collect::<Vec<&str>>(),
+            "delegates": &cred.delegates,
+        });
+
+        let req = serde_json::to_vec(&req)?;
+
+        let resp = self
+            .client
+            .post(&cred.service_account_impersonation_url)
+            .header(CONTENT_TYPE, "application/json")
+            .bearer_auth(temp_token.access_token)
+            .body(req)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            error!("access token loader for impersonated service account got unexpected response: {:?}", resp);
+            bail!("access token loader for impersonated service account failed: {}", resp.text().await?);
+        }
+
+        let token: Option<ImpersonatedToken> = serde_json::from_slice(&resp.bytes().await?)?;
+        let token = token.expect("couldn't parse access token response");
+
+        Ok(Token::new(&token.access_token, 3600, &temp_token.scope))
+    }
+}

--- a/src/google/token/impersonated_service_account.rs
+++ b/src/google/token/impersonated_service_account.rs
@@ -77,7 +77,7 @@ impl TokenLoader {
     ) -> Result<Token> {
         let req = serde_json::json!({
             "lifetime": format!("{}s", MAX_LIFETIME.as_secs()),
-            "scope": &temp_token.scope.split(" ").collect::<Vec<&str>>(),
+            "scope": &temp_token.scope.split(' ').collect::<Vec<&str>>(),
             "delegates": &cred.delegates,
         });
 

--- a/src/google/token/impersonated_service_account.rs
+++ b/src/google/token/impersonated_service_account.rs
@@ -33,7 +33,9 @@ impl TokenLoader {
         };
 
         let bearer_auth_token = self.generate_bearer_auth_token(cred).await?;
-        self.generate_access_token(cred, bearer_auth_token).await.map(Some)
+        self.generate_access_token(cred, bearer_auth_token)
+            .await
+            .map(Some)
     }
 
     async fn generate_bearer_auth_token(&self, cred: &ImpersonatedServiceAccount) -> Result<Token> {
@@ -56,7 +58,10 @@ impl TokenLoader {
 
         if !resp.status().is_success() {
             error!("bearer token loader for impersonated service account got unexpected response: {:?}", resp);
-            bail!("bearer token loader for impersonated service account failed: {}", resp.text().await?);
+            bail!(
+                "bearer token loader for impersonated service account failed: {}",
+                resp.text().await?
+            );
         }
 
         let token: Option<Token> = serde_json::from_slice(&resp.bytes().await?)?;
@@ -65,7 +70,11 @@ impl TokenLoader {
         Ok(token)
     }
 
-    async fn generate_access_token(&self, cred: &ImpersonatedServiceAccount, temp_token: Token) -> Result<Token> {
+    async fn generate_access_token(
+        &self,
+        cred: &ImpersonatedServiceAccount,
+        temp_token: Token,
+    ) -> Result<Token> {
         let req = serde_json::json!({
             "lifetime": format!("{}s", MAX_LIFETIME.as_secs()),
             "scope": &temp_token.scope.split(" ").collect::<Vec<&str>>(),
@@ -85,7 +94,10 @@ impl TokenLoader {
 
         if !resp.status().is_success() {
             error!("access token loader for impersonated service account got unexpected response: {:?}", resp);
-            bail!("access token loader for impersonated service account failed: {}", resp.text().await?);
+            bail!(
+                "access token loader for impersonated service account failed: {}",
+                resp.text().await?
+            );
         }
 
         let token: Option<ImpersonatedToken> = serde_json::from_slice(&resp.bytes().await?)?;

--- a/testdata/services/google/test_impersonated_service_account.json
+++ b/testdata/services/google/test_impersonated_service_account.json
@@ -1,0 +1,11 @@
+{
+    "delegates": [],
+    "service_account_impersonation_url": "xxx",
+    "source_credentials": {
+        "client_id": "xxx",
+        "client_secret": "xxx",
+        "refresh_token": "xxx",
+        "type": "authorized_user"
+    },
+    "type": "impersonated_service_account"
+}

--- a/testdata/services/google/test_impersonated_service_account.json
+++ b/testdata/services/google/test_impersonated_service_account.json
@@ -1,10 +1,10 @@
 {
     "delegates": [],
-    "service_account_impersonation_url": "xxx",
+    "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/example-01-iam@example-01.iam.gserviceaccount.com:generateAccessToken",
     "source_credentials": {
-        "client_id": "xxx",
-        "client_secret": "xxx",
-        "refresh_token": "xxx",
+        "client_id": "placeholder_client_id",
+        "client_secret": "placeholder_client_secret",
+        "refresh_token": "placeholder_refresh_token",
         "type": "authorized_user"
     },
     "type": "impersonated_service_account"


### PR DESCRIPTION
The function names/variable names/error messages inside the `TokenLoader` impl might be wrong. I'm not really sure of all the terminology! Please let me know if I can improve them.

I'm also not super experienced with rust, so please let me know if anything is non-idiomatic as well, and I'll try and improve it.

I tested this branch by building OpenDAL against it, and I was able to successfully read a file from a bucket with an impersonated service account.

x-ref: #402 