### PR TITLE
deps: bump reqwest, chrone, rust-ini

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,19 +65,19 @@ name = "aws"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-base64 = "0.22"
+base64 = "0.21"
 chrono = "0.4.24"
 form_urlencoded = "1"
 hex = "0.4"
 hmac = "0.12"
-http = "0.2"
+http = "1.1"
 jsonwebtoken = { version = "9.2", optional = true }
 log = "0.4"
 once_cell = { version = "1", optional = true }
 percent-encoding = "2"
 quick-xml = { version = "0.31", features = ["serialize"], optional = true }
 rand = "0.8.5"
-reqwest = { version = "0.11", default-features = false, optional = true }
+reqwest = { version = "0.12", default-features = false, optional = true }
 rsa = { version = "0.9.2", features = ["pkcs5", "sha2"], optional = true }
 rust-ini = { version = "0.20", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,35 +24,35 @@ reqwest_request = ["dep:reqwest"]
 
 # services that reqsign supports
 services-all = [
-  "services-aliyun",
-  "services-aws",
-  "services-azblob",
-  "services-google",
-  "services-huaweicloud",
-  "services-oracle",
-  "services-tencent",
+    "services-aliyun",
+    "services-aws",
+    "services-azblob",
+    "services-google",
+    "services-huaweicloud",
+    "services-oracle",
+    "services-tencent",
 ]
 
 services-aliyun = [
-  "dep:reqwest",
-  "dep:serde",
-  "dep:serde_json",
-  "dep:once_cell",
+    "dep:reqwest",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:once_cell",
 ]
 services-aws = [
-  "dep:reqwest",
-  "dep:serde",
-  "dep:serde_json",
-  "dep:quick-xml",
-  "dep:rust-ini",
+    "dep:reqwest",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:quick-xml",
+    "dep:rust-ini",
 ]
 services-azblob = ["dep:serde", "dep:serde_json", "dep:reqwest"]
 services-google = [
-  "dep:reqwest",
-  "dep:serde",
-  "dep:serde_json",
-  "dep:jsonwebtoken",
-  "dep:rsa",
+    "dep:reqwest",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:jsonwebtoken",
+    "dep:rsa",
 ]
 services-huaweicloud = ["dep:serde", "dep:serde_json", "dep:once_cell"]
 services-oracle = ["dep:reqwest", "dep:rsa", "dep:toml", "dep:serde"]
@@ -65,8 +65,8 @@ name = "aws"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-base64 = "0.21"
-chrono = "0.4.24"
+base64 = "0.22"
+chrono = "0.4.35"
 form_urlencoded = "1"
 hex = "0.4"
 hmac = "0.12"
@@ -79,7 +79,7 @@ quick-xml = { version = "0.31", features = ["serialize"], optional = true }
 rand = "0.8.5"
 reqwest = { version = "0.12", default-features = false, optional = true }
 rsa = { version = "0.9.2", features = ["pkcs5", "sha2"], optional = true }
-rust-ini = { version = "0.20", optional = true }
+rust-ini = { version = "0.21", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 sha1 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,13 +95,14 @@ getrandom = { version = "0.2", features = ["js"] }
 tokio = { version = "1", optional = true }
 
 [dev-dependencies]
-aws-sigv4 = "0.56"
+aws-credential-types = "1.1.8"
+aws-sigv4 = "1.2.0"
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
 dotenv = "0.15"
 env_logger = "0.11"
 once_cell = "1"
 pretty_assertions = "1.3"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
+reqwest = { version = "0.12", features = ["blocking", "json"] }
 temp-env = "0.3"
 tempfile = "3.8"
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,9 +100,11 @@ aws-sigv4 = "1.2.0"
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
 dotenv = "0.15"
 env_logger = "0.11"
+macro_rules_attribute = "0.2.0"
 once_cell = "1"
 pretty_assertions = "1.3"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 temp-env = "0.3"
 tempfile = "3.8"
+test-case = "3.3.1"
 tokio = { version = "1", features = ["full"] }

--- a/src/aliyun/credential.rs
+++ b/src/aliyun/credential.rs
@@ -39,7 +39,7 @@ impl Credential {
         // Take 120s as buffer to avoid edge cases.
         if let Some(valid) = self
             .expires_in
-            .map(|v| v > now() + chrono::Duration::try_minutes(2).expect("in bounds"))
+            .map(|v| v > now() + chrono::TimeDelta::try_minutes(2).expect("in bounds"))
         {
             return valid;
         }
@@ -115,7 +115,7 @@ impl Loader {
                 security_token: self.config.security_token.clone(),
                 // Set expires_in to 10 minutes to enforce re-read
                 // from file.
-                expires_in: Some(now() + chrono::Duration::try_minutes(10).expect("in bounds")),
+                expires_in: Some(now() + chrono::TimeDelta::try_minutes(10).expect("in bounds")),
             }))
         } else {
             Ok(None)

--- a/src/aliyun/credential.rs
+++ b/src/aliyun/credential.rs
@@ -39,7 +39,7 @@ impl Credential {
         // Take 120s as buffer to avoid edge cases.
         if let Some(valid) = self
             .expires_in
-            .map(|v| v > now() + chrono::Duration::minutes(2))
+            .map(|v| v > now() + chrono::Duration::try_minutes(2).expect("in bounds"))
         {
             return valid;
         }
@@ -115,7 +115,7 @@ impl Loader {
                 security_token: self.config.security_token.clone(),
                 // Set expires_in to 10 minutes to enforce re-read
                 // from file.
-                expires_in: Some(now() + chrono::Duration::minutes(10)),
+                expires_in: Some(now() + chrono::Duration::try_minutes(10).expect("in bounds")),
             }))
         } else {
             Ok(None)

--- a/src/aliyun/oss.rs
+++ b/src/aliyun/oss.rs
@@ -67,7 +67,7 @@ impl Signer {
                 ctx.query_push("OSSAccessKeyId", &cred.access_key_id);
                 ctx.query_push(
                     "Expires",
-                    (now + chrono::Duration::from_std(expire).unwrap())
+                    (now + chrono::TimeDelta::from_std(expire).unwrap())
                         .timestamp()
                         .to_string(),
                 );
@@ -135,7 +135,7 @@ fn string_to_sign(
             writeln!(
                 &mut s,
                 "{}",
-                (now + chrono::Duration::from_std(expires).unwrap()).timestamp()
+                (now + chrono::TimeDelta::from_std(expires).unwrap()).timestamp()
             )?;
         }
     }

--- a/src/aws/credential.rs
+++ b/src/aws/credential.rs
@@ -48,7 +48,7 @@ impl Credential {
         // Take 120s as buffer to avoid edge cases.
         if let Some(valid) = self
             .expires_in
-            .map(|v| v > now() + chrono::Duration::minutes(2))
+            .map(|v| v > now() + chrono::Duration::try_minutes(2).expect("in bounds"))
         {
             return valid;
         }
@@ -159,7 +159,7 @@ impl DefaultLoader {
                 session_token: self.config.session_token.clone(),
                 // Set expires_in to 10 minutes to enforce re-read
                 // from file.
-                expires_in: Some(now() + chrono::Duration::minutes(10)),
+                expires_in: Some(now() + chrono::Duration::try_minutes(10).expect("in bounds")),
             }))
         } else {
             Ok(None)
@@ -356,7 +356,8 @@ impl IMDSv2Loader {
         }
         let ec2_token = resp.text().await?;
         // Set expires_in to 10 minutes to enforce re-read.
-        let expires_in = now() + chrono::Duration::seconds(21600) - chrono::Duration::seconds(600);
+        let expires_in = now() + chrono::Duration::try_seconds(21600).expect("in bounds")
+            - chrono::Duration::try_seconds(600).expect("in bounds");
 
         {
             *self.token.lock().expect("lock poisoned") = (ec2_token.clone(), expires_in);

--- a/src/aws/credential.rs
+++ b/src/aws/credential.rs
@@ -48,7 +48,7 @@ impl Credential {
         // Take 120s as buffer to avoid edge cases.
         if let Some(valid) = self
             .expires_in
-            .map(|v| v > now() + chrono::Duration::try_minutes(2).expect("in bounds"))
+            .map(|v| v > now() + chrono::TimeDelta::try_minutes(2).expect("in bounds"))
         {
             return valid;
         }
@@ -159,7 +159,7 @@ impl DefaultLoader {
                 session_token: self.config.session_token.clone(),
                 // Set expires_in to 10 minutes to enforce re-read
                 // from file.
-                expires_in: Some(now() + chrono::Duration::try_minutes(10).expect("in bounds")),
+                expires_in: Some(now() + chrono::TimeDelta::try_minutes(10).expect("in bounds")),
             }))
         } else {
             Ok(None)
@@ -356,8 +356,8 @@ impl IMDSv2Loader {
         }
         let ec2_token = resp.text().await?;
         // Set expires_in to 10 minutes to enforce re-read.
-        let expires_in = now() + chrono::Duration::try_seconds(21600).expect("in bounds")
-            - chrono::Duration::try_seconds(600).expect("in bounds");
+        let expires_in = now() + chrono::TimeDelta::try_seconds(21600).expect("in bounds")
+            - chrono::TimeDelta::try_seconds(600).expect("in bounds");
 
         {
             *self.token.lock().expect("lock poisoned") = (ec2_token.clone(), expires_in);

--- a/src/azure/storage/sas/account_sas.rs
+++ b/src/azure/storage/sas/account_sas.rs
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn test_can_generate_sas_token() {
         let key = hash::base64_encode("key".as_bytes());
-        let expiry = test_time() + chrono::Duration::minutes(5);
+        let expiry = test_time() + chrono::Duration::try_minutes(5).expect("in bounds");
         let sign = AccountSharedAccessSignature::new("account".to_string(), key, expiry);
         let token_content = sign.token().expect("token decode failed");
         let token = token_content

--- a/src/azure/storage/sas/account_sas.rs
+++ b/src/azure/storage/sas/account_sas.rs
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn test_can_generate_sas_token() {
         let key = hash::base64_encode("key".as_bytes());
-        let expiry = test_time() + chrono::Duration::try_minutes(5).expect("in bounds");
+        let expiry = test_time() + chrono::TimeDelta::try_minutes(5).expect("in bounds");
         let sign = AccountSharedAccessSignature::new("account".to_string(), key, expiry);
         let token_content = sign.token().expect("token decode failed");
         let token = token_content

--- a/src/azure/storage/signer.rs
+++ b/src/azure/storage/signer.rs
@@ -81,7 +81,7 @@ impl Signer {
                     let signer = account_sas::AccountSharedAccessSignature::new(
                         ak.to_string(),
                         sk.to_string(),
-                        time::now() + chrono::Duration::from_std(d)?,
+                        time::now() + chrono::TimeDelta::from_std(d)?,
                     );
                     let signer_token = signer.token()?;
                     signer_token.iter().for_each(|(k, v)| {

--- a/src/google/token.rs
+++ b/src/google/token.rs
@@ -179,7 +179,7 @@ impl TokenLoader {
         match self.token.lock().expect("lock poisoned").clone() {
             Some((token, expire_in))
                 if now()
-                    < expire_in - chrono::Duration::try_seconds(2 * 60).expect("in bounds") =>
+                    < expire_in - chrono::TimeDelta::try_seconds(2 * 60).expect("in bounds") =>
             {
                 return Ok(Some(token))
             }
@@ -193,7 +193,7 @@ impl TokenLoader {
         };
 
         let expire_in =
-            now() + chrono::Duration::try_seconds(token.expires_in() as i64).expect("in bounds");
+            now() + chrono::TimeDelta::try_seconds(token.expires_in() as i64).expect("in bounds");
 
         let mut lock = self.token.lock().expect("lock poisoned");
         *lock = Some((token.clone(), expire_in));

--- a/src/google/token.rs
+++ b/src/google/token.rs
@@ -177,7 +177,10 @@ impl TokenLoader {
     /// Load token from different sources.
     pub async fn load(&self) -> Result<Option<Token>> {
         match self.token.lock().expect("lock poisoned").clone() {
-            Some((token, expire_in)) if now() < expire_in - chrono::Duration::seconds(2 * 60) => {
+            Some((token, expire_in))
+                if now()
+                    < expire_in - chrono::Duration::try_seconds(2 * 60).expect("in bounds") =>
+            {
                 return Ok(Some(token))
             }
             _ => (),
@@ -189,7 +192,8 @@ impl TokenLoader {
             return Ok(None);
         };
 
-        let expire_in = now() + chrono::Duration::seconds(token.expires_in() as i64);
+        let expire_in =
+            now() + chrono::Duration::try_seconds(token.expires_in() as i64).expect("in bounds");
 
         let mut lock = self.token.lock().expect("lock poisoned");
         *lock = Some((token.clone(), expire_in));

--- a/src/huaweicloud/obs/signer.rs
+++ b/src/huaweicloud/obs/signer.rs
@@ -83,7 +83,7 @@ impl Signer {
                 ctx.query_push("AccessKeyId", &cred.access_key_id);
                 ctx.query_push(
                     "Expires",
-                    (now + chrono::Duration::from_std(expire).unwrap())
+                    (now + chrono::TimeDelta::from_std(expire).unwrap())
                         .timestamp()
                         .to_string(),
                 );
@@ -182,7 +182,7 @@ fn string_to_sign(
             writeln!(
                 &mut s,
                 "{}",
-                (now + chrono::Duration::from_std(expires).unwrap()).timestamp()
+                (now + chrono::TimeDelta::from_std(expires).unwrap()).timestamp()
             )?;
         }
     }

--- a/src/oracle/credential.rs
+++ b/src/oracle/credential.rs
@@ -84,7 +84,7 @@ impl Loader {
             fingerprint: config.fingerprint,
             // Set expires_in to 10 minutes to enforce re-read
             // from file.
-            expires_in: Some(now() + chrono::Duration::try_minutes(10).expect("in bounds")),
+            expires_in: Some(now() + chrono::TimeDelta::try_minutes(10).expect("in bounds")),
         }))
     }
 }

--- a/src/oracle/credential.rs
+++ b/src/oracle/credential.rs
@@ -84,7 +84,7 @@ impl Loader {
             fingerprint: config.fingerprint,
             // Set expires_in to 10 minutes to enforce re-read
             // from file.
-            expires_in: Some(now() + chrono::Duration::minutes(10)),
+            expires_in: Some(now() + chrono::Duration::try_minutes(10).expect("in bounds")),
         }))
     }
 }

--- a/src/tencent/cos.rs
+++ b/src/tencent/cos.rs
@@ -124,7 +124,7 @@ fn build_signature(
     let key_time = format!(
         "{};{}",
         now.timestamp(),
-        (now + chrono::Duration::from_std(expires).unwrap()).timestamp()
+        (now + chrono::TimeDelta::from_std(expires).unwrap()).timestamp()
     );
 
     let sign_key = hex_hmac_sha1(cred.secret_key.as_bytes(), key_time.as_bytes());

--- a/src/tencent/credential.rs
+++ b/src/tencent/credential.rs
@@ -96,7 +96,7 @@ impl CredentialLoader {
                 security_token: self.config.security_token.clone(),
                 // Set expires_in to 10 minutes to enforce re-read
                 // from file.
-                expires_in: Some(now() + chrono::Duration::minutes(10)),
+                expires_in: Some(now() + chrono::Duration::try_minutes(10).expect("in bounds")),
             };
             return Ok(Some(cred));
         }

--- a/src/tencent/credential.rs
+++ b/src/tencent/credential.rs
@@ -96,7 +96,7 @@ impl CredentialLoader {
                 security_token: self.config.security_token.clone(),
                 // Set expires_in to 10 minutes to enforce re-read
                 // from file.
-                expires_in: Some(now() + chrono::Duration::try_minutes(10).expect("in bounds")),
+                expires_in: Some(now() + chrono::TimeDelta::try_minutes(10).expect("in bounds")),
             };
             return Ok(Some(cred));
         }


### PR DESCRIPTION
This PR bumps reqwest (and by extension the rest of the hyper / http ecosustem to 1.0).

Note that I have also moved construction of the request out of the signing benchmark since the new API requires that we convert all the headers to strings which impacts the results. So now the bench is only the actual signing itself plus a clone of the processed headers.
