### PR TITLE
Bump to version 0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "reqsign"
 repository = "https://github.com/Xuanwo/reqsign"
-version = "0.14.9"
+version = "0.15.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
reqwest is part of our public API, so we bump major version this time.