### PR TITLE
ci: migrate to macos-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-12
+          - macos-13
           - windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-12
+          - macos-13
           - windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-11
+          - macos-12
           - windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-11
+          - macos-12
           - windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/check
@@ -26,9 +26,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - macos-13
-          - windows-latest
+          - windows-2022
     steps:
       - uses: actions/checkout@v4
       - name: Build
@@ -37,7 +37,7 @@ jobs:
           command: build
 
   build_under_wasm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build
@@ -46,7 +46,7 @@ jobs:
           cargo build --target wasm32-unknown-unknown
 
   build_single_feature:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         feature:
@@ -70,9 +70,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - macos-13
-          - windows-latest
+          - windows-2022
     steps:
       - uses: actions/checkout@v4
       - name: Build
@@ -82,7 +82,7 @@ jobs:
           args: --all-features
 
   unit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
     steps:
@@ -133,7 +133,7 @@ jobs:
         run: cargo test --doc
 
   test_gcs_web_identify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: "read"
       id-token: "write"
@@ -159,7 +159,7 @@ jobs:
           REQSIGN_GOOGLE_CREDENTIAL_PATH: ${{steps.auth.outputs.credentials_file_path}}
 
   test_tencent_cloud_web_identify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: "read"
       id-token: "write"
@@ -192,7 +192,7 @@ jobs:
           REQSIGN_TENCENT_COS_REGION: ${{ secrets.REQSIGN_TENCENT_COS_REGION }}
 
   test_aws_web_identity:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: "read"
       id-token: "write"


### PR DESCRIPTION
The macos-11 label has been deprecated and will no longer be available after 28 June 2024.