### PR TITLE
fix(io): replace std::fs in async fns with tokio::fs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --no-default-features --features reqwest_request,${{ matrix.feature }}
+          args: --no-default-features --features reqwest_request,tokio_fs,${{ matrix.feature }}
 
   build_all_features:
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,15 @@ version = "0.16.0"
 [package.metadata.docs.rs]
 all-features = true
 
+
 [features]
-default = ["reqwest_request", "services-all"]
+default = ["reqwest_request", "services-all", "tokio_fs"]
 
 native-tls = ["reqwest?/default-tls"]
 rustls = ["reqwest?/rustls-tls"]
+
+tokio_fs = ["tokio/fs"]
+blocking_io = []
 
 # requests that reqwest supports
 reqwest_blocking_request = ["reqwest?/blocking"]
@@ -58,6 +62,10 @@ services-huaweicloud = ["dep:serde", "dep:serde_json", "dep:once_cell"]
 services-oracle = ["dep:reqwest", "dep:rsa", "dep:toml", "dep:serde"]
 services-tencent = ["dep:reqwest", "dep:serde", "dep:serde_json"]
 
+[target.'cfg(target_arch = "wasm32")'.features]
+default = ["reqwest_request", "services-all"]
+
+
 [[bench]]
 harness = false
 name = "aws"
@@ -88,11 +96,11 @@ toml = { version = "0.8.9", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 home = "0.5"
-tokio = { version = "1", features = ["fs"] }
+tokio = { version = "1", features = ["fs"], optional=true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-tokio = { version = "1" }
+tokio = { version = "1", optional=true }
 
 [dev-dependencies]
 aws-credential-types = "1.1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,11 +88,11 @@ toml = { version = "0.8.9", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 home = "0.5"
-tokio = { version = "1", features = ["fs"], optional = true }
+tokio = { version = "1", features = ["fs"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-tokio = { version = "1", optional = true }
+tokio = { version = "1" }
 
 [dev-dependencies]
 aws-credential-types = "1.1.8"

--- a/src/aliyun/credential.rs
+++ b/src/aliyun/credential.rs
@@ -136,7 +136,9 @@ impl Loader {
             }
             _ => return Ok(None),
         };
-
+        #[cfg(target_arch = "wasm32")]
+        let token = fs::read_to_string(token_file)?;
+        #[cfg(not(target_arch = "wasm32"))]
         let token = fs::read_to_string(token_file).await?;
         let role_session_name = &self.config.role_session_name;
 

--- a/src/aliyun/credential.rs
+++ b/src/aliyun/credential.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -7,6 +6,7 @@ use anyhow::Result;
 use log::debug;
 use reqwest::Client;
 use serde::Deserialize;
+use tokio::fs;
 
 use super::config::Config;
 use crate::time::format_rfc3339;
@@ -134,7 +134,7 @@ impl Loader {
             _ => return Ok(None),
         };
 
-        let token = fs::read_to_string(token_file)?;
+        let token = fs::read_to_string(token_file).await?;
         let role_session_name = &self.config.role_session_name;
 
         // Construct request to Aliyun STS Service.
@@ -296,7 +296,7 @@ mod tests {
                 .expect("current_dir must exist")
                 .to_string_lossy()
         );
-        fs::write(&file_path, token)?;
+        std::fs::write(&file_path, token)?;
 
         temp_env::with_vars(
             vec![
@@ -395,7 +395,7 @@ mod tests {
                 .expect("current_dir must exist")
                 .to_string_lossy()
         );
-        fs::write(&file_path, token)?;
+        std::fs::write(&file_path, token)?;
 
         temp_env::with_vars(
             vec![

--- a/src/aliyun/credential.rs
+++ b/src/aliyun/credential.rs
@@ -6,6 +6,9 @@ use anyhow::Result;
 use log::debug;
 use reqwest::Client;
 use serde::Deserialize;
+#[cfg(target_arch = "wasm32")]
+use std::fs;
+#[cfg(not(target_arch = "wasm32"))]
 use tokio::fs;
 
 use super::config::Config;

--- a/src/aliyun/credential.rs
+++ b/src/aliyun/credential.rs
@@ -6,10 +6,6 @@ use anyhow::Result;
 use log::debug;
 use reqwest::Client;
 use serde::Deserialize;
-#[cfg(target_arch = "wasm32")]
-use std::fs;
-#[cfg(not(target_arch = "wasm32"))]
-use tokio::fs;
 
 use super::config::Config;
 use crate::time::format_rfc3339;
@@ -136,10 +132,7 @@ impl Loader {
             }
             _ => return Ok(None),
         };
-        #[cfg(target_arch = "wasm32")]
-        let token = fs::read_to_string(token_file)?;
-        #[cfg(not(target_arch = "wasm32"))]
-        let token = fs::read_to_string(token_file).await?;
+        let token = crate::io::read_file_to_string(token_file).await?;
         let role_session_name = &self.config.role_session_name;
 
         // Construct request to Aliyun STS Service.

--- a/src/aws/credential.rs
+++ b/src/aws/credential.rs
@@ -182,6 +182,9 @@ impl DefaultLoader {
                 _ => return Ok(None),
             };
 
+        #[cfg(target_arch = "wasm32")]
+        let token = fs::read_to_string(token_file)?;
+        #[cfg(not(target_arch = "wasm32"))]
         let token = fs::read_to_string(token_file).await?;
         let role_session_name = &self.config.role_session_name;
 

--- a/src/aws/credential.rs
+++ b/src/aws/credential.rs
@@ -1,6 +1,5 @@
 use std::fmt::Debug;
 use std::fmt::Write;
-use std::fs;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -12,6 +11,7 @@ use log::debug;
 use quick_xml::de;
 use reqwest::Client;
 use serde::Deserialize;
+use tokio::fs;
 
 use super::config::Config;
 use super::constants::X_AMZ_CONTENT_SHA_256;
@@ -182,7 +182,7 @@ impl DefaultLoader {
                 _ => return Ok(None),
             };
 
-        let token = fs::read_to_string(token_file)?;
+        let token = fs::read_to_string(token_file).await?;
         let role_session_name = &self.config.role_session_name;
 
         let endpoint = self.sts_endpoint()?;
@@ -769,7 +769,7 @@ mod tests {
                 .expect("current_dir must exist")
                 .to_string_lossy()
         );
-        fs::write(&file_path, github_token)?;
+        std::fs::write(&file_path, github_token)?;
 
         temp_env::with_vars(
             vec![
@@ -849,7 +849,7 @@ mod tests {
                 .expect("current_dir must exist")
                 .to_string_lossy()
         );
-        fs::write(&file_path, github_token)?;
+        std::fs::write(&file_path, github_token)?;
 
         temp_env::with_vars(
             vec![

--- a/src/aws/credential.rs
+++ b/src/aws/credential.rs
@@ -11,7 +11,6 @@ use log::debug;
 use quick_xml::de;
 use reqwest::Client;
 use serde::Deserialize;
-use tokio::fs;
 
 use super::config::Config;
 use super::constants::X_AMZ_CONTENT_SHA_256;
@@ -182,10 +181,7 @@ impl DefaultLoader {
                 _ => return Ok(None),
             };
 
-        #[cfg(target_arch = "wasm32")]
-        let token = fs::read_to_string(token_file)?;
-        #[cfg(not(target_arch = "wasm32"))]
-        let token = fs::read_to_string(token_file).await?;
+        let token = crate::io::read_file_to_string(token_file).await?;
         let role_session_name = &self.config.role_session_name;
 
         let endpoint = self.sts_endpoint()?;

--- a/src/azure/storage/workload_identity_credential.rs
+++ b/src/azure/storage/workload_identity_credential.rs
@@ -28,6 +28,9 @@ pub async fn get_workload_identity_token(config: &Config) -> anyhow::Result<Opti
         _ => return Ok(None),
     };
 
+    #[cfg(target_arch = "wasm32")]
+    let token = fs::read_to_string(token_file)?;
+    #[cfg(not(target_arch = "wasm32"))]
     let token = fs::read_to_string(token_file).await?;
     let url = Url::parse(authority_host)?.join(&format!("/{tenant_id}/oauth2/v2.0/token"))?;
     let scopes: &[&str] = &[STORAGE_TOKEN_SCOPE];

--- a/src/azure/storage/workload_identity_credential.rs
+++ b/src/azure/storage/workload_identity_credential.rs
@@ -6,7 +6,6 @@ use http::Request;
 use reqwest::Client;
 use reqwest::Url;
 use serde::Deserialize;
-use tokio::fs;
 
 use super::config::Config;
 
@@ -28,10 +27,7 @@ pub async fn get_workload_identity_token(config: &Config) -> anyhow::Result<Opti
         _ => return Ok(None),
     };
 
-    #[cfg(target_arch = "wasm32")]
-    let token = fs::read_to_string(token_file)?;
-    #[cfg(not(target_arch = "wasm32"))]
-    let token = fs::read_to_string(token_file).await?;
+    let token = crate::io::read_file_to_string(token_file).await?;
     let url = Url::parse(authority_host)?.join(&format!("/{tenant_id}/oauth2/v2.0/token"))?;
     let scopes: &[&str] = &[STORAGE_TOKEN_SCOPE];
     let encoded_body: String = form_urlencoded::Serializer::new(String::new())

--- a/src/azure/storage/workload_identity_credential.rs
+++ b/src/azure/storage/workload_identity_credential.rs
@@ -1,4 +1,4 @@
-use std::{fs, str};
+use std::str;
 
 use http::HeaderValue;
 use http::Method;
@@ -6,6 +6,7 @@ use http::Request;
 use reqwest::Client;
 use reqwest::Url;
 use serde::Deserialize;
+use tokio::fs;
 
 use super::config::Config;
 
@@ -27,7 +28,7 @@ pub async fn get_workload_identity_token(config: &Config) -> anyhow::Result<Opti
         _ => return Ok(None),
     };
 
-    let token = fs::read_to_string(token_file)?;
+    let token = fs::read_to_string(token_file).await?;
     let url = Url::parse(authority_host)?.join(&format!("/{tenant_id}/oauth2/v2.0/token"))?;
     let scopes: &[&str] = &[STORAGE_TOKEN_SCOPE];
     let encoded_body: String = form_urlencoded::Serializer::new(String::new())

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,6 @@
+pub async fn read_file_to_string(path: &str) -> std::io::Result<String> {
+    #[cfg(target_arch = "wasm32")]
+    return std::fs::read_to_string(path);
+    #[cfg(not(target_arch = "wasm32"))]
+    return tokio::fs::read_to_string(path).await;
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,6 +1,9 @@
 pub async fn read_file_to_string(path: &str) -> std::io::Result<String> {
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(any(target_arch = "wasm32", feature = "blocking_io"))]
     return std::fs::read_to_string(path);
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        all(feature = "tokio_fs", not(feature = "blocking_io"))
+    ))]
     return tokio::fs::read_to_string(path).await;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,5 +88,6 @@ pub use tencent::*;
 mod ctx;
 mod dirs;
 mod hash;
+mod io;
 mod request;
 mod time;

--- a/src/tencent/credential.rs
+++ b/src/tencent/credential.rs
@@ -10,7 +10,6 @@ use log::debug;
 use reqwest::Client;
 use serde::Deserialize;
 use serde::Serialize;
-use tokio::fs;
 
 use super::config::Config;
 use crate::time::now;
@@ -138,10 +137,7 @@ impl CredentialLoader {
             }
         };
 
-        #[cfg(target_arch = "wasm32")]
-        let token = fs::read_to_string(token_file)?;
-        #[cfg(not(target_arch = "wasm32"))]
-        let token = fs::read_to_string(token_file).await?;
+        let token = crate::io::read_file_to_string(token_file).await?;
         let role_session_name = &self.config.role_session_name;
 
         // Construct request to Tencent Cloud STS Service.

--- a/src/tencent/credential.rs
+++ b/src/tencent/credential.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -11,6 +10,7 @@ use log::debug;
 use reqwest::Client;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::fs;
 
 use super::config::Config;
 use crate::time::now;
@@ -138,7 +138,7 @@ impl CredentialLoader {
             }
         };
 
-        let token = fs::read_to_string(token_file)?;
+        let token = fs::read_to_string(token_file).await?;
         let role_session_name = &self.config.role_session_name;
 
         // Construct request to Tencent Cloud STS Service.
@@ -315,7 +315,7 @@ mod tests {
                 .expect("current_dir must exist")
                 .to_string_lossy()
         );
-        fs::write(&file_path, github_token)?;
+        std::fs::write(&file_path, github_token)?;
 
         temp_env::with_vars(
             vec![

--- a/src/tencent/credential.rs
+++ b/src/tencent/credential.rs
@@ -138,6 +138,9 @@ impl CredentialLoader {
             }
         };
 
+        #[cfg(target_arch = "wasm32")]
+        let token = fs::read_to_string(token_file)?;
+        #[cfg(not(target_arch = "wasm32"))]
         let token = fs::read_to_string(token_file).await?;
         let role_session_name = &self.config.role_session_name;
 


### PR DESCRIPTION
This PR replaces blocking fs calls with async fs calls. Using blocking reads can cause unexpected hangs in async code https://ryhl.io/blog/async-what-is-blocking/

This does not address other blocking IO calls as they exist in e.g. `src/google/credential.rs:CredentialLoader::load_file` which may also be used in async contexts as changing these methods would be a breaking change.