### PR TITLE
AWS S3: Add support for assume role duration seconds

### DIFF
--- a/src/aws/config.rs
+++ b/src/aws/config.rs
@@ -84,7 +84,7 @@ pub struct Config {
     /// - this field if it's `is_some`.
     /// - profile config: `duration_seconds`
     /// - default to `3600`.
-    pub duration_seconds: Option<i32>,
+    pub duration_seconds: Option<usize>,
     /// `external_id` value will be load from:
     ///
     /// - this field if it's `is_some`.
@@ -272,7 +272,7 @@ impl Config {
             self.role_session_name = v.to_string()
         }
         if let Some(v) = props.get("duration_seconds") {
-            self.duration_seconds = Some(v.to_string().parse::<i32>().unwrap())
+            self.duration_seconds = Some(v.to_string().parse::<usize>().unwrap())
         }
         if let Some(v) = props.get("web_identity_token_file") {
             self.web_identity_token_file = Some(v.to_string())

--- a/src/aws/config.rs
+++ b/src/aws/config.rs
@@ -79,12 +79,12 @@ pub struct Config {
     /// - profile config: `role_session_name`
     /// - default to `reqsign`.
     pub role_session_name: String,
-    /// `role_session_duration` value will be load from:
+    /// `duration_seconds` value will be load from:
     ///
     /// - this field if it's `is_some`.
     /// - profile config: `duration_seconds`
     /// - default to `3600`.
-    pub role_session_duration: Option<i32>,
+    pub duration_seconds: Option<i32>,
     /// `external_id` value will be load from:
     ///
     /// - this field if it's `is_some`.
@@ -116,7 +116,7 @@ impl Default for Config {
             session_token: None,
             role_arn: None,
             role_session_name: "reqsign".to_string(),
-            role_session_duration: Some(3600),
+            duration_seconds: Some(3600),
             external_id: None,
             web_identity_token_file: None,
             ec2_metadata_disabled: false,
@@ -272,7 +272,7 @@ impl Config {
             self.role_session_name = v.to_string()
         }
         if let Some(v) = props.get("duration_seconds") {
-            self.role_session_duration = Some(v.to_string().parse::<i32>().unwrap())
+            self.duration_seconds = Some(v.to_string().parse::<i32>().unwrap())
         }
         if let Some(v) = props.get("web_identity_token_file") {
             self.web_identity_token_file = Some(v.to_string())

--- a/src/aws/config.rs
+++ b/src/aws/config.rs
@@ -79,6 +79,12 @@ pub struct Config {
     /// - profile config: `role_session_name`
     /// - default to `reqsign`.
     pub role_session_name: String,
+    /// `role_session_duration` value will be load from:
+    ///
+    /// - this field if it's `is_some`.
+    /// - profile config: `duration_seconds`
+    /// - default to `3600`.
+    pub role_session_duration: Option<i32>,
     /// `external_id` value will be load from:
     ///
     /// - this field if it's `is_some`.
@@ -110,6 +116,7 @@ impl Default for Config {
             session_token: None,
             role_arn: None,
             role_session_name: "reqsign".to_string(),
+            role_session_duration: Some(3600),
             external_id: None,
             web_identity_token_file: None,
             ec2_metadata_disabled: false,
@@ -263,6 +270,9 @@ impl Config {
         }
         if let Some(v) = props.get("role_session_name") {
             self.role_session_name = v.to_string()
+        }
+        if let Some(v) = props.get("duration_seconds") {
+            self.role_session_duration = Some(v.to_string().parse::<i32>().unwrap())
         }
         if let Some(v) = props.get("web_identity_token_file") {
             self.web_identity_token_file = Some(v.to_string())

--- a/src/aws/credential.rs
+++ b/src/aws/credential.rs
@@ -419,6 +419,9 @@ impl AssumeRoleLoader {
         if let Some(external_id) = &self.config.external_id {
             write!(url, "&ExternalId={external_id}")?;
         }
+        if let Some(role_session_duration) = &self.config.role_session_duration {
+            write!(url, "&DurationSeconds={role_session_duration}")?;
+        }
 
         let req = http::request::Request::builder()
             .method("GET")

--- a/src/aws/credential.rs
+++ b/src/aws/credential.rs
@@ -419,8 +419,8 @@ impl AssumeRoleLoader {
         if let Some(external_id) = &self.config.external_id {
             write!(url, "&ExternalId={external_id}")?;
         }
-        if let Some(role_session_duration) = &self.config.role_session_duration {
-            write!(url, "&DurationSeconds={role_session_duration}")?;
+        if let Some(duration_seconds) = &self.config.duration_seconds {
+            write!(url, "&DurationSeconds={duration_seconds}")?;
         }
 
         let req = http::request::Request::builder()


### PR DESCRIPTION
Changes Done 

Adds support for configuring session duration while assume role. Defaults to 3600 seconds 

Fixes https://github.com/Xuanwo/reqsign/issues/465 

