### PR TITLE
docs: correct signer term usage

### DIFF
--- a/src/aliyun/oss.rs
+++ b/src/aliyun/oss.rs
@@ -1,4 +1,4 @@
-//! Aliyun OSS Singer
+//! Aliyun OSS Signer
 
 use std::collections::HashSet;
 use std::fmt::Write;
@@ -23,7 +23,7 @@ use crate::time::DateTime;
 
 const CONTENT_MD5: &str = "content-md5";
 
-/// Singer for Aliyun OSS.
+/// Signer for Aliyun OSS.
 pub struct Signer {
     bucket: String,
 }

--- a/src/aws/v4.rs
+++ b/src/aws/v4.rs
@@ -27,7 +27,7 @@ use crate::time::format_iso8601;
 use crate::time::now;
 use crate::time::DateTime;
 
-/// Singer that implement AWS SigV4.
+/// Signer that implement AWS SigV4.
 ///
 /// - [Signature Version 4 signing process](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
 #[derive(Debug)]

--- a/src/azure/storage/mod.rs
+++ b/src/azure/storage/mod.rs
@@ -1,4 +1,4 @@
-//! Azure Storage Singer
+//! Azure Storage Signer
 
 mod signer;
 

--- a/src/azure/storage/signer.rs
+++ b/src/azure/storage/signer.rs
@@ -1,4 +1,4 @@
-//! Azure Storage Singer
+//! Azure Storage Signer
 
 use std::fmt::Debug;
 use std::fmt::Write;
@@ -21,7 +21,7 @@ use crate::time;
 use crate::time::format_http_date;
 use crate::time::DateTime;
 
-/// Singer that implement Azure Storage Shared Key Authorization.
+/// Signer that implement Azure Storage Shared Key Authorization.
 ///
 /// - [Authorize with Shared Key](https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key)
 #[derive(Debug, Default)]

--- a/src/google/signer.rs
+++ b/src/google/signer.rs
@@ -22,7 +22,7 @@ use crate::time::format_date;
 use crate::time::format_iso8601;
 use crate::time::DateTime;
 
-/// Singer that implement Google OAuth2 Authentication.
+/// Signer that implement Google OAuth2 Authentication.
 ///
 /// ## Reference
 ///

--- a/src/huaweicloud/obs/signer.rs
+++ b/src/huaweicloud/obs/signer.rs
@@ -22,7 +22,7 @@ use crate::time::format_http_date;
 use crate::time::now;
 use crate::time::DateTime;
 
-/// Singer that implement Huawei Cloud Object Storage Service Authorization.
+/// Signer that implement Huawei Cloud Object Storage Service Authorization.
 ///
 /// - [User Signature Authentication](https://support.huaweicloud.com/intl/en-us/api-obs/obs_04_0009.html)
 #[derive(Debug)]

--- a/src/oracle/oci.rs
+++ b/src/oracle/oci.rs
@@ -1,4 +1,4 @@
-//! Oracle Cloud Infrastructure Singer
+//! Oracle Cloud Infrastructure Signer
 
 use anyhow::{Error, Result};
 use base64::{engine::general_purpose, Engine as _};
@@ -18,7 +18,7 @@ use crate::ctx::SigningContext;
 use crate::time;
 use crate::time::DateTime;
 
-/// Singer for Oracle Cloud Infrastructure using API Key.
+/// Signer for Oracle Cloud Infrastructure using API Key.
 #[derive(Default)]
 pub struct APIKeySigner {}
 

--- a/src/tencent/cos.rs
+++ b/src/tencent/cos.rs
@@ -1,4 +1,4 @@
-//! Tencent COS Singer
+//! Tencent COS Signer
 
 use std::time::Duration;
 
@@ -20,7 +20,7 @@ use crate::time;
 use crate::time::format_http_date;
 use crate::time::DateTime;
 
-/// Singer for Tencent COS.
+/// Signer for Tencent COS.
 #[derive(Default)]
 pub struct Signer {
     time: Option<DateTime>,


### PR DESCRIPTION
Small typo I noticed whilst browsing around. 

I first noticed it on the `google` service and checked elsewhere with `rg "Singer"` to find the rest.
