### PR TITLE
feat: parse endpoint_url from profile and env

### DIFF
--- a/services/aws-v4/src/config.rs
+++ b/services/aws-v4/src/config.rs
@@ -98,6 +98,11 @@ pub struct Config {
     /// - this field
     /// - env value: [`AWS_EC2_METADATA_DISABLED`]
     pub ec2_metadata_disabled: bool,
+    /// `endpoint_url` value will be loaded from:
+    ///
+    /// - this field
+    /// - env value: [`AWS_ENDPOINT_URL`]
+    pub endpoint_url: Option<String>,
 }
 
 impl Default for Config {
@@ -118,6 +123,7 @@ impl Default for Config {
             tags: None,
             web_identity_token_file: None,
             ec2_metadata_disabled: false,
+            endpoint_url: None,
         }
     }
 }
@@ -162,6 +168,9 @@ impl Config {
         }
         if let Some(v) = envs.get(AWS_EC2_METADATA_DISABLED) {
             self.ec2_metadata_disabled = v == "true";
+        }
+        if let Some(v) = envs.get(AWS_ENDPOINT_URL) {
+            self.endpoint_url = Some(v.to_string());
         }
         self
     }
@@ -276,6 +285,9 @@ impl Config {
         if let Some(v) = props.get("web_identity_token_file") {
             self.web_identity_token_file = Some(v.to_string())
         }
+        if let Some(v) = props.get("endpoint_url") {
+            self.endpoint_url = Some(v.to_string())
+        }
 
         Ok(())
     }
@@ -358,6 +370,7 @@ mod tests {
         writeln!(tmp_file, "aws_access_key_id = PROFILE1ACCESSKEYID")?;
         writeln!(tmp_file, "aws_secret_access_key = PROFILE1SECRETACCESSKEY")?;
         writeln!(tmp_file, "aws_session_token = PROFILE1SESSIONTOKEN")?;
+        writeln!(tmp_file, "endpoint_url = http://localhost:8080")?;
 
         let context = Context::new(TokioFileRead, ReqwestHttpSend::default());
         let context = context.with_env(StaticEnv {
@@ -382,6 +395,10 @@ mod tests {
         assert_eq!(
             config.session_token,
             Some("PROFILE1SESSIONTOKEN".to_owned())
+        );
+        assert_eq!(
+            config.endpoint_url,
+            Some("http://localhost:8080".to_owned())
         );
 
         Ok(())

--- a/services/aws-v4/src/constants.rs
+++ b/services/aws-v4/src/constants.rs
@@ -19,7 +19,7 @@ pub const AWS_ROLE_ARN: &str = "AWS_ROLE_ARN";
 pub const AWS_ROLE_SESSION_NAME: &str = "AWS_ROLE_SESSION_NAME";
 pub const AWS_STS_REGIONAL_ENDPOINTS: &str = "AWS_STS_REGIONAL_ENDPOINTS";
 pub const AWS_EC2_METADATA_DISABLED: &str = "AWS_EC2_METADATA_DISABLED";
-
+pub const AWS_ENDPOINT_URL: &str = "AWS_ENDPOINT_URL";
 /// AsciiSet for [AWS UriEncode](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)
 ///
 /// - URI encode every byte except the unreserved characters: 'A'-'Z', 'a'-'z', '0'-'9', '-', '.', '_', and '~'.


### PR DESCRIPTION
The PR only add parsing support, however, it doesn't break anything so I think it's good enough.

It's a bit troublesome to verify whether this environment variable will affect the behavior of AWS STS, so we can check it later.

BTW, it's better to create a separate crate specifically for loading AWS profiles. This way, adding fields that reqsign might not be concerned with won't cause any issues.