### PR TITLE
feat: Add support for credential retrieval in ECS Fargate environment

### DIFF
--- a/src/aws/config.rs
+++ b/src/aws/config.rs
@@ -105,6 +105,11 @@ pub struct Config {
     /// - this field
     /// - env value: [`AWS_EC2_METADATA_DISABLED`]
     pub ec2_metadata_disabled: bool,
+    /// `container_credentials_disabled` value will be loaded from:
+    ///
+    /// - this field
+    /// - env value: [`AWS_CONTAINER_CREDENTIALS_DISABLED`]
+    pub container_credentials_disabled: bool,
     /// `endpoint_url` value will be loaded from:
     ///
     /// - this field
@@ -130,6 +135,7 @@ impl Default for Config {
             tags: None,
             web_identity_token_file: None,
             ec2_metadata_disabled: false,
+            container_credentials_disabled: false,
             endpoint_url: None,
         }
     }
@@ -175,6 +181,9 @@ impl Config {
         }
         if let Some(v) = envs.get(AWS_EC2_METADATA_DISABLED) {
             self.ec2_metadata_disabled = v == "true";
+        }
+        if let Some(v) = envs.get(AWS_CONTAINER_CREDENTIALS_DISABLED) {
+            self.container_credentials_disabled = v == "true";
         }
         if let Some(v) = envs.get(AWS_ENDPOINT_URL) {
             self.endpoint_url = Some(v.to_string());

--- a/src/aws/constants.rs
+++ b/src/aws/constants.rs
@@ -20,6 +20,9 @@ pub const AWS_ROLE_SESSION_NAME: &str = "AWS_ROLE_SESSION_NAME";
 pub const AWS_STS_REGIONAL_ENDPOINTS: &str = "AWS_STS_REGIONAL_ENDPOINTS";
 pub const AWS_EC2_METADATA_DISABLED: &str = "AWS_EC2_METADATA_DISABLED";
 pub const AWS_ENDPOINT_URL: &str = "AWS_ENDPOINT_URL";
+pub const AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: &str = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+pub const AWS_CONTAINER_CREDENTIALS_FULL_URI: &str = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
+pub const AWS_CONTAINER_CREDENTIALS_DISABLED: &str = "AWS_CONTAINER_CREDENTIALS_DISABLED";
 /// AsciiSet for [AWS UriEncode](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)
 ///
 /// - URI encode every byte except the unreserved characters: 'A'-'Z', 'a'-'z', '0'-'9', '-', '.', '_', and '~'.

--- a/src/aws/credential.rs
+++ b/src/aws/credential.rs
@@ -14,9 +14,9 @@ use reqwest::Client;
 use serde::Deserialize;
 
 use super::config::Config;
-use super::constants::X_AMZ_CONTENT_SHA_256;
-use super::constants::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI;
 use super::constants::AWS_CONTAINER_CREDENTIALS_FULL_URI;
+use super::constants::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI;
+use super::constants::X_AMZ_CONTENT_SHA_256;
 use super::v4::Signer;
 use crate::time::now;
 use crate::time::parse_rfc3339;


### PR DESCRIPTION
# Add support for credential retrieval in ECS Fargate environment

## Overview

This PR adds support for automatic credential retrieval in ECS Fargate environments by implementing the ECS task metadata endpoint integration. This enables applications running in ECS Fargate to automatically obtain credentials from task roles without manual configuration.

## Changes

- **Add ECSLoader**: New loader that supports `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` and `AWS_CONTAINER_CREDENTIALS_FULL_URI` environment variables
- **Enhance DefaultLoader**: Add ECS credential retrieval to the credential resolution order (after IMDSv2, before fallback)
- **Extend Config**: Add `container_credentials_disabled` field to allow disabling ECS credential retrieval via `AWS_CONTAINER_CREDENTIALS_DISABLED` environment variable
- **Add constants**: Define ECS-related environment variable constants
- **Implement ECS endpoint**: Support credential retrieval from ECS task metadata endpoint (`http://169.254.170.2`)

## Target Branch

This PR targets the `v0.16.x` branch instead of `main` because the main branch is currently undergoing major structural changes that would make this implementation incompatible. Once the main branch stabilizes, this feature can be ported to the new architecture.
