### PR TITLE
feat: Add ECS credential provider for Fargate support

### DIFF
--- a/services/aws-v4/src/config.rs
+++ b/services/aws-v4/src/config.rs
@@ -98,6 +98,11 @@ pub struct Config {
     /// - this field
     /// - env value: [`AWS_EC2_METADATA_DISABLED`]
     pub ec2_metadata_disabled: bool,
+    /// `container_credentials_disabled` value will be loaded from:
+    ///
+    /// - this field
+    /// - env value: [`AWS_CONTAINER_CREDENTIALS_DISABLED`]
+    pub container_credentials_disabled: bool,
     /// `endpoint_url` value will be loaded from:
     ///
     /// - this field
@@ -123,6 +128,7 @@ impl Default for Config {
             tags: None,
             web_identity_token_file: None,
             ec2_metadata_disabled: false,
+            container_credentials_disabled: false,
             endpoint_url: None,
         }
     }
@@ -146,6 +152,10 @@ impl fmt::Debug for Config {
             .field("tags", &self.tags)
             .field("web_identity_token_file", &self.web_identity_token_file)
             .field("ec2_metadata_disabled", &self.ec2_metadata_disabled)
+            .field(
+                "container_credentials_disabled",
+                &self.container_credentials_disabled,
+            )
             .field("endpoint_url", &self.endpoint_url)
             .finish()
     }
@@ -191,6 +201,9 @@ impl Config {
         }
         if let Some(v) = envs.get(AWS_EC2_METADATA_DISABLED) {
             self.ec2_metadata_disabled = v == "true";
+        }
+        if let Some(v) = envs.get(AWS_CONTAINER_CREDENTIALS_DISABLED) {
+            self.container_credentials_disabled = v == "true";
         }
         if let Some(v) = envs.get(AWS_ENDPOINT_URL) {
             self.endpoint_url = Some(v.to_string());

--- a/services/aws-v4/src/constants.rs
+++ b/services/aws-v4/src/constants.rs
@@ -20,6 +20,9 @@ pub const AWS_ROLE_SESSION_NAME: &str = "AWS_ROLE_SESSION_NAME";
 pub const AWS_STS_REGIONAL_ENDPOINTS: &str = "AWS_STS_REGIONAL_ENDPOINTS";
 pub const AWS_EC2_METADATA_DISABLED: &str = "AWS_EC2_METADATA_DISABLED";
 pub const AWS_ENDPOINT_URL: &str = "AWS_ENDPOINT_URL";
+pub const AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: &str = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+pub const AWS_CONTAINER_CREDENTIALS_FULL_URI: &str = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
+pub const AWS_CONTAINER_CREDENTIALS_DISABLED: &str = "AWS_CONTAINER_CREDENTIALS_DISABLED";
 /// AsciiSet for [AWS UriEncode](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)
 ///
 /// - URI encode every byte except the unreserved characters: 'A'-'Z', 'a'-'z', '0'-'9', '-', '.', '_', and '~'.

--- a/services/aws-v4/src/provide_credential/default.rs
+++ b/services/aws-v4/src/provide_credential/default.rs
@@ -1,6 +1,6 @@
 use crate::provide_credential::{
-    AssumeRoleWithWebIdentityCredentialProvider, EnvCredentialProvider, IMDSv2CredentialProvider,
-    ProfileCredentialProvider,
+    AssumeRoleWithWebIdentityCredentialProvider, EcsCredentialProvider, EnvCredentialProvider,
+    IMDSv2CredentialProvider, ProfileCredentialProvider,
 };
 use crate::{Config, Credential};
 use async_trait::async_trait;
@@ -14,7 +14,7 @@ use std::sync::Arc;
 /// 1. Environment variables
 /// 2. Shared config (`~/.aws/config`, `~/.aws/credentials`)
 /// 3. Web Identity Tokens
-/// 4. ECS (IAM Roles for Tasks) & General HTTP credentials (TODO)
+/// 4. ECS (IAM Roles for Tasks)
 /// 5. EC2 IMDSv2
 #[derive(Debug)]
 pub struct DefaultCredentialProvider {
@@ -30,6 +30,7 @@ impl DefaultCredentialProvider {
             .push(AssumeRoleWithWebIdentityCredentialProvider::new(
                 config.clone(),
             ))
+            .push(EcsCredentialProvider::new(config.clone()))
             .push(IMDSv2CredentialProvider::new(config));
 
         Self { chain }

--- a/services/aws-v4/src/provide_credential/ecs.rs
+++ b/services/aws-v4/src/provide_credential/ecs.rs
@@ -1,0 +1,141 @@
+use crate::constants::{
+    AWS_CONTAINER_CREDENTIALS_FULL_URI, AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,
+};
+use crate::{Config, Credential};
+use async_trait::async_trait;
+use bytes::Bytes;
+use http::Method;
+use reqsign_core::time::parse_rfc3339;
+use reqsign_core::{Context, Error, ProvideCredential, Result};
+use serde::Deserialize;
+use std::sync::Arc;
+
+/// EcsCredentialProvider will load credential from ECS task metadata endpoint.
+///
+/// ECS credential provider provides credentials for ECS tasks using
+/// the AWS_CONTAINER_CREDENTIALS_RELATIVE_URI or AWS_CONTAINER_CREDENTIALS_FULL_URI
+/// environment variables.
+///
+/// References:
+/// - [IAM roles for tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
+#[derive(Debug)]
+pub struct EcsCredentialProvider {
+    config: Arc<Config>,
+}
+
+impl EcsCredentialProvider {
+    /// Create a new `EcsCredentialProvider` instance.
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for EcsCredentialProvider {
+    fn default() -> Self {
+        Self::new(Arc::new(Config::default()))
+    }
+}
+
+#[async_trait]
+impl ProvideCredential for EcsCredentialProvider {
+    type Credential = Credential;
+
+    async fn provide_credential(&self, ctx: &Context) -> Result<Option<Self::Credential>> {
+        // If container_credentials_disabled is set, return None.
+        if self.config.container_credentials_disabled {
+            return Ok(None);
+        }
+
+        let envs = ctx.env_vars();
+
+        // Check if we're in an ECS environment
+        let relative_uri = envs.get(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI);
+        let full_uri = envs.get(AWS_CONTAINER_CREDENTIALS_FULL_URI);
+
+        let url = match (relative_uri, full_uri) {
+            (Some(relative), _) => {
+                // Use relative URI with the standard metadata endpoint
+                format!("http://169.254.170.2{}", relative)
+            }
+            (None, Some(full)) => {
+                // Use full URI directly
+                full.to_string()
+            }
+            (None, None) => {
+                // Not in an ECS environment
+                return Ok(None);
+            }
+        };
+
+        // Make request to ECS metadata endpoint
+        let req = http::Request::builder()
+            .uri(&url)
+            .method(Method::GET)
+            .body(Bytes::new())
+            .map_err(|e| {
+                Error::unexpected("failed to build ECS metadata request").with_source(e)
+            })?;
+
+        let resp = ctx.http_send_as_string(req).await?;
+
+        if resp.status() != http::StatusCode::OK {
+            return Err(Error::unexpected(format!(
+                "request to ECS task metadata endpoint failed: status={}, body={}",
+                resp.status(),
+                resp.body()
+            )));
+        }
+
+        let content = resp.into_body();
+        let cred: EcsTaskCredentials = serde_json::from_str(&content).map_err(|e| {
+            Error::unexpected("failed to parse ECS task credentials").with_source(e)
+        })?;
+
+        let expires_in = parse_rfc3339(&cred.expiration)
+            .map_err(|e| Error::unexpected("failed to parse expiration time").with_source(e))?;
+
+        Ok(Some(Credential {
+            access_key_id: cred.access_key_id,
+            secret_access_key: cred.secret_access_key,
+            session_token: Some(cred.token),
+            expires_in: Some(expires_in),
+        }))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct EcsTaskCredentials {
+    #[serde(rename = "AccessKeyId")]
+    access_key_id: String,
+    #[serde(rename = "SecretAccessKey")]
+    secret_access_key: String,
+    #[serde(rename = "Token")]
+    token: String,
+    #[serde(rename = "Expiration")]
+    expiration: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqsign_core::StaticEnv;
+    use reqsign_file_read_tokio::TokioFileRead;
+    use reqsign_http_send_reqwest::ReqwestHttpSend;
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn test_ecs_credential_provider_without_env() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let ctx = Context::new(TokioFileRead, ReqwestHttpSend::default());
+        let ctx = ctx.with_env(StaticEnv {
+            home_dir: None,
+            envs: HashMap::new(),
+        });
+
+        let provider = EcsCredentialProvider::new(Arc::new(Config::default()));
+        let result = provider.provide_credential(&ctx).await.unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/services/aws-v4/src/provide_credential/mod.rs
+++ b/services/aws-v4/src/provide_credential/mod.rs
@@ -7,6 +7,9 @@ pub use assume_role_with_web_identity::AssumeRoleWithWebIdentityCredentialProvid
 mod default;
 pub use default::DefaultCredentialProvider;
 
+mod ecs;
+pub use ecs::EcsCredentialProvider;
+
 mod env;
 pub use env::EnvCredentialProvider;
 


### PR DESCRIPTION
## Summary

This PR adds support for AWS ECS credential provider to enable credential retrieval in AWS ECS Fargate environments. The implementation follows the same pattern as the existing IMDSv2 credential provider and integrates seamlessly into the default credential chain.

## Features

### ECS Credential Provider
- Supports both `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` and `AWS_CONTAINER_CREDENTIALS_FULL_URI` environment variables
- Automatically detects ECS environment and retrieves credentials from task metadata endpoint
- Handles credential expiration parsing and error cases gracefully
- Can be disabled via `AWS_CONTAINER_CREDENTIALS_DISABLED` environment variable

### Updated Credential Resolution Order
The default credential provider now follows this resolution order:
1. Environment variables
2. Shared config (`~/.aws/config`, `~/.aws/credentials`)
3. Web Identity Tokens
4. **ECS (IAM Roles for Tasks)** ← New
5. EC2 IMDSv2

## Implementation Details

- The ECS provider checks `container_credentials_disabled` configuration internally, following the same pattern as IMDSv2 provider
- Uses the standard ECS task metadata endpoint `http://169.254.170.2` for relative URIs
- Supports full URIs for custom metadata endpoints

## References

- [AWS ECS IAM roles for tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
