### PR TITLE
feat(services/aws-v4): Add direct configuration support to ECSCredentialProvider

### DIFF
--- a/services/aws-v4/src/provide_credential/ecs.rs
+++ b/services/aws-v4/src/provide_credential/ecs.rs
@@ -160,8 +160,7 @@ impl ECSCredentialProvider {
         if let Some(relative_uri) = &self.relative_uri {
             let base_endpoint = self
                 .metadata_uri_override
-                .as_ref()
-                .map(|s| s.as_str())
+                .as_deref()
                 .unwrap_or(ECS_METADATA_ENDPOINT);
             return Ok(format!("{base_endpoint}{relative_uri}"));
         }

--- a/services/aws-v4/src/provide_credential/ecs.rs
+++ b/services/aws-v4/src/provide_credential/ecs.rs
@@ -23,16 +23,47 @@ const ECS_CONTAINER_METADATA_URI: &str = "ECS_CONTAINER_METADATA_URI";
 /// endpoints provide information about the task and container, the credentials
 /// endpoint provides IAM role credentials for authentication.
 ///
-/// # Environment Variables
+/// # Configuration
+///
+/// Configuration values can be provided directly via builder methods or through environment
+/// variables. Direct configuration takes precedence over environment variables.
+///
+/// ## Builder Methods
+/// - [`with_relative_uri()`]: Set the relative URI for ECS environments
+/// - [`with_endpoint()`]: Set a complete custom endpoint URL (for Fargate or custom setups)
+/// - [`with_auth_token()`]: Set the authorization token directly
+/// - [`with_auth_token_file()`]: Set the path to the authorization token file
+/// - [`with_metadata_uri_override()`]: Override the base metadata endpoint for relative URIs
+///
+/// ## Environment Variables (Fallback)
 /// - `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`: Relative URI to fetch credentials (ECS)
 /// - `AWS_CONTAINER_CREDENTIALS_FULL_URI`: Full URI to fetch credentials (Fargate)
 /// - `AWS_CONTAINER_AUTHORIZATION_TOKEN`: Authorization token for the request
 /// - `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`: File containing the authorization token
 /// - `ECS_CONTAINER_METADATA_URI`: Override the default base endpoint (for testing)
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use reqsign_aws_v4::ECSCredentialProvider;
+///
+/// // Configure for ECS with relative URI
+/// let provider = ECSCredentialProvider::new()
+///     .with_relative_uri("/v2/credentials/task-role")
+///     .with_auth_token("my-auth-token");
+///
+/// // Configure for Fargate with full endpoint
+/// let provider = ECSCredentialProvider::new()
+///     .with_endpoint("http://169.254.170.2/v2/credentials/task-role")
+///     .with_auth_token_file("/tmp/auth-token");
+/// ```
 #[derive(Debug, Clone)]
 pub struct ECSCredentialProvider {
     endpoint: Option<String>,
     auth_token: Option<String>,
+    auth_token_file: Option<String>,
+    relative_uri: Option<String>,
+    metadata_uri_override: Option<String>,
 }
 
 impl Default for ECSCredentialProvider {
@@ -47,6 +78,9 @@ impl ECSCredentialProvider {
         Self {
             endpoint: None,
             auth_token: None,
+            auth_token_file: None,
+            relative_uri: None,
+            metadata_uri_override: None,
         }
     }
 
@@ -62,10 +96,40 @@ impl ECSCredentialProvider {
         self
     }
 
+    /// Create with custom auth token file path
+    pub fn with_auth_token_file(mut self, file_path: impl Into<String>) -> Self {
+        self.auth_token_file = Some(file_path.into());
+        self
+    }
+
+    /// Create with container credentials relative URI
+    /// This is used in ECS environments where the base metadata URI is known
+    pub fn with_relative_uri(mut self, uri: impl Into<String>) -> Self {
+        self.relative_uri = Some(uri.into());
+        self
+    }
+
+    /// Override the metadata URI base endpoint (typically for testing)
+    /// Defaults to http://169.254.170.2 if not specified
+    pub fn with_metadata_uri_override(mut self, uri: impl Into<String>) -> Self {
+        self.metadata_uri_override = Some(uri.into());
+        self
+    }
+
     async fn load_auth_token(&self, ctx: &Context) -> Result<Option<String>> {
         // If auth token is already set, use it
         if let Some(token) = &self.auth_token {
             return Ok(Some(token.clone()));
+        }
+
+        // Try to get token from configured file first
+        if let Some(token_file) = &self.auth_token_file {
+            let token = ctx.file_read(token_file).await.map_err(|e| {
+                Error::config_invalid("failed to read ECS auth token file")
+                    .with_source(e)
+                    .with_context(format!("file: {}", token_file))
+            })?;
+            return Ok(Some(String::from_utf8_lossy(&token).trim().to_string()));
         }
 
         // Try to get token from environment
@@ -73,7 +137,7 @@ impl ECSCredentialProvider {
             return Ok(Some(token));
         }
 
-        // Try to get token from file
+        // Try to get token from environment file
         if let Some(token_file) = ctx.env_var(AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE) {
             let token = ctx.file_read(&token_file).await.map_err(|e| {
                 Error::config_invalid("failed to read ECS auth token file")
@@ -87,29 +151,43 @@ impl ECSCredentialProvider {
     }
 
     fn get_endpoint(&self, ctx: &Context) -> Result<String> {
-        // Use custom endpoint if provided
+        // Use custom endpoint if provided (highest priority)
         if let Some(endpoint) = &self.endpoint {
             return Ok(endpoint.clone());
         }
 
-        // Try full URI first (Fargate)
+        // Try configured relative URI (ECS)
+        if let Some(relative_uri) = &self.relative_uri {
+            let base_endpoint = self
+                .metadata_uri_override
+                .as_ref()
+                .map(|s| s.as_str())
+                .unwrap_or(ECS_METADATA_ENDPOINT);
+            return Ok(format!("{base_endpoint}{relative_uri}"));
+        }
+
+        // Fall back to environment variables
+        // Try full URI from environment (Fargate)
         if let Some(full_uri) = ctx.env_var(AWS_CONTAINER_CREDENTIALS_FULL_URI) {
             return Ok(full_uri);
         }
 
-        // Try relative URI (ECS)
+        // Try relative URI from environment (ECS)
         if let Some(relative_uri) = ctx.env_var(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI) {
             // Allow override of metadata endpoint for testing
-            let base_endpoint = ctx
-                .env_var(ECS_CONTAINER_METADATA_URI)
-                .unwrap_or_else(|| ECS_METADATA_ENDPOINT.to_string());
+            let base_endpoint = match &self.metadata_uri_override {
+                Some(override_uri) => override_uri.clone(),
+                None => ctx
+                    .env_var(ECS_CONTAINER_METADATA_URI)
+                    .unwrap_or_else(|| ECS_METADATA_ENDPOINT.to_string()),
+            };
             return Ok(format!("{base_endpoint}{relative_uri}"));
         }
 
         Err(Error::config_invalid(
             "ECS container credentials endpoint not configured"
         )
-        .with_context("hint: set AWS_CONTAINER_CREDENTIALS_RELATIVE_URI or AWS_CONTAINER_CREDENTIALS_FULL_URI")
+        .with_context("hint: use with_relative_uri(), with_endpoint(), or set AWS_CONTAINER_CREDENTIALS_RELATIVE_URI/AWS_CONTAINER_CREDENTIALS_FULL_URI")
         .with_context("note: are you running on ECS or Fargate?"))
     }
 }
@@ -312,5 +390,179 @@ mod tests {
 
         let endpoint = provider.get_endpoint(&ctx).unwrap();
         assert_eq!(endpoint, "http://custom-endpoint/creds");
+    }
+
+    #[tokio::test]
+    async fn test_configured_relative_uri() {
+        let ctx = Context::new()
+            .with_file_read(TokioFileRead)
+            .with_http_send(ReqwestHttpSend::default())
+            .with_env(StaticEnv {
+                home_dir: None,
+                envs: HashMap::new(),
+            });
+
+        let provider = ECSCredentialProvider::new().with_relative_uri("/v2/credentials/task-role");
+
+        let endpoint = provider.get_endpoint(&ctx).unwrap();
+        assert_eq!(endpoint, "http://169.254.170.2/v2/credentials/task-role");
+    }
+
+    #[tokio::test]
+    async fn test_configured_relative_uri_with_custom_base() {
+        let ctx = Context::new()
+            .with_file_read(TokioFileRead)
+            .with_http_send(ReqwestHttpSend::default())
+            .with_env(StaticEnv {
+                home_dir: None,
+                envs: HashMap::new(),
+            });
+
+        let provider = ECSCredentialProvider::new()
+            .with_relative_uri("/creds")
+            .with_metadata_uri_override("http://localhost:51679");
+
+        let endpoint = provider.get_endpoint(&ctx).unwrap();
+        assert_eq!(endpoint, "http://localhost:51679/creds");
+    }
+
+    #[tokio::test]
+    async fn test_configured_values_override_env() {
+        let ctx = Context::new()
+            .with_file_read(TokioFileRead)
+            .with_http_send(ReqwestHttpSend::default())
+            .with_env(StaticEnv {
+                home_dir: None,
+                envs: HashMap::from_iter([
+                    (
+                        AWS_CONTAINER_CREDENTIALS_FULL_URI.to_string(),
+                        "http://env-endpoint/creds".to_string(),
+                    ),
+                    (
+                        AWS_CONTAINER_CREDENTIALS_RELATIVE_URI.to_string(),
+                        "/env-relative".to_string(),
+                    ),
+                ]),
+            });
+
+        let provider =
+            ECSCredentialProvider::new().with_endpoint("http://configured-endpoint/creds");
+
+        let endpoint = provider.get_endpoint(&ctx).unwrap();
+        // Configured value should override environment
+        assert_eq!(endpoint, "http://configured-endpoint/creds");
+    }
+
+    #[tokio::test]
+    async fn test_priority_order() {
+        let ctx = Context::new()
+            .with_file_read(TokioFileRead)
+            .with_http_send(ReqwestHttpSend::default())
+            .with_env(StaticEnv {
+                home_dir: None,
+                envs: HashMap::from_iter([(
+                    AWS_CONTAINER_CREDENTIALS_FULL_URI.to_string(),
+                    "http://env-full-uri/creds".to_string(),
+                )]),
+            });
+
+        // Test priority: custom endpoint > relative URI > env
+        let provider = ECSCredentialProvider::new()
+            .with_endpoint("http://custom/creds")
+            .with_relative_uri("/relative");
+
+        let endpoint = provider.get_endpoint(&ctx).unwrap();
+        assert_eq!(endpoint, "http://custom/creds");
+
+        // Test without custom endpoint
+        let provider = ECSCredentialProvider::new().with_relative_uri("/relative");
+
+        let endpoint = provider.get_endpoint(&ctx).unwrap();
+        assert_eq!(endpoint, "http://169.254.170.2/relative");
+    }
+
+    #[tokio::test]
+    async fn test_configured_auth_token() {
+        let ctx = Context::new()
+            .with_file_read(TokioFileRead)
+            .with_http_send(ReqwestHttpSend::default())
+            .with_env(StaticEnv {
+                home_dir: None,
+                envs: HashMap::from_iter([(
+                    AWS_CONTAINER_AUTHORIZATION_TOKEN.to_string(),
+                    "env-token".to_string(),
+                )]),
+            });
+
+        let provider = ECSCredentialProvider::new().with_auth_token("configured-token");
+
+        let token = provider.load_auth_token(&ctx).await.unwrap();
+        // Configured token should override environment
+        assert_eq!(token, Some("configured-token".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_configured_auth_token_file() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        writeln!(temp_file, "file-token").unwrap();
+        let temp_path = temp_file.path().to_str().unwrap();
+
+        let ctx = Context::new()
+            .with_file_read(TokioFileRead)
+            .with_http_send(ReqwestHttpSend::default())
+            .with_env(StaticEnv {
+                home_dir: None,
+                envs: HashMap::from_iter([
+                    (
+                        AWS_CONTAINER_AUTHORIZATION_TOKEN.to_string(),
+                        "env-token".to_string(),
+                    ),
+                    (
+                        AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE.to_string(),
+                        "env-file.txt".to_string(),
+                    ),
+                ]),
+            });
+
+        let provider = ECSCredentialProvider::new().with_auth_token_file(temp_path);
+
+        let token = provider.load_auth_token(&ctx).await.unwrap();
+        // Configured file should override environment
+        assert_eq!(token, Some("file-token".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_auth_token_priority() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        writeln!(temp_file, "file-token").unwrap();
+        let temp_path = temp_file.path().to_str().unwrap();
+
+        let ctx = Context::new()
+            .with_file_read(TokioFileRead)
+            .with_http_send(ReqwestHttpSend::default())
+            .with_env(StaticEnv {
+                home_dir: None,
+                envs: HashMap::new(),
+            });
+
+        // Test priority: direct token > configured file > env token > env file
+        let provider = ECSCredentialProvider::new()
+            .with_auth_token("direct-token")
+            .with_auth_token_file(temp_path);
+
+        let token = provider.load_auth_token(&ctx).await.unwrap();
+        assert_eq!(token, Some("direct-token".to_string()));
+
+        // Test without direct token
+        let provider = ECSCredentialProvider::new().with_auth_token_file(temp_path);
+
+        let token = provider.load_auth_token(&ctx).await.unwrap();
+        assert_eq!(token, Some("file-token".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

- Added direct configuration support to `ECSCredentialProvider` via new builder methods
- Configuration via builder methods takes precedence over environment variables
- Maintained backward compatibility with existing environment variable approach

## New Builder Methods

- `with_relative_uri()`: Configure relative URI for ECS environments
- `with_auth_token_file()`: Set path to authorization token file  
- `with_metadata_uri_override()`: Override base metadata endpoint for relative URIs

## Benefits

- Enables programmatic configuration without relying on environment variables
- Useful for containerized environments where setting env vars may not be practical
- Provides more flexible credential configuration options
- Addresses the need to supply `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, `AWS_CONTAINER_CREDENTIALS_FULL_URI`, or `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` externally

## Test Plan

- [x] Added comprehensive unit tests for all new configuration methods
- [x] Tested priority order: direct config > environment variables
- [x] Verified backward compatibility with existing environment variable usage
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)