### PR TITLE
chore: remove useless `reqwest` requirement

### DIFF
--- a/services/aws-v4/Cargo.toml
+++ b/services/aws-v4/Cargo.toml
@@ -24,7 +24,6 @@ log.workspace = true
 percent-encoding.workspace = true
 quick-xml.workspace = true
 reqsign-core.workspace = true
-reqwest.workspace = true
 rust-ini.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/services/azure-storage/Cargo.toml
+++ b/services/azure-storage/Cargo.toml
@@ -20,7 +20,6 @@ http.workspace = true
 log.workspace = true
 percent-encoding.workspace = true
 reqsign-core.workspace = true
-reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha1.workspace = true

--- a/services/huaweicloud-obs/Cargo.toml
+++ b/services/huaweicloud-obs/Cargo.toml
@@ -24,6 +24,5 @@ env_logger.workspace = true
 once_cell.workspace = true
 reqsign-file-read-tokio.workspace = true
 reqsign-http-send-reqwest.workspace = true
-reqwest = { workspace = true, features = ["rustls-tls"] }
 temp-env.workspace = true
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
reqwest is not required in aws, azure and huawei cloud. Remove it to make dependencies neat.