### PR TITLE
Build docs for all features on docs.rs

### DIFF
--- a/reqsign/Cargo.toml
+++ b/reqsign/Cargo.toml
@@ -27,6 +27,9 @@ categories = ["authentication", "web-programming::http-client"]
 description = "Signing HTTP requests for AWS, Azure, Google, Huawei, Aliyun, Tencent and Oracle services"
 keywords = ["http", "requests", "signing", "aws", "azure"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 # Core functionality (always included)
 reqsign-core.workspace = true


### PR DESCRIPTION
This change will tell docs.rs to build the docs with all features enabled, see [here](https://docs.rs/about/metadata).

This will make the docs show all cloud-specific modules:
<img width="809" height="370" alt="Screenshot 2025-09-11 at 11 01 47" src="https://github.com/user-attachments/assets/7dc2e03d-78f5-4c96-b733-a29e3a63a11c" />
