### PR TITLE
fix: Fix failure of custom_client example to build in http-send-reqwest

### DIFF
--- a/context/http-send-reqwest/Cargo.toml
+++ b/context/http-send-reqwest/Cargo.toml
@@ -32,8 +32,8 @@ bytes.workspace = true
 http.workspace = true
 http-body-util = "0.1.2"
 reqsign-core.workspace = true
-reqwest = { version = "0.12", default-features = false }
+reqwest = { workspace = true, default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-reqwest = { version = "0.12", default-features = false, features = ["default-tls"] }
+reqwest = { workspace = true, default-features = false, features = ["default-tls"] }


### PR DESCRIPTION
Fixes #636 by adding a dev-dependency on `reqwest` with the `default-tls` feature enabled.

Also converts the `reqwest` dependencies in this crate to workspace dependencies. Other crates in the repository already use the workspace `reqwest`, and this avoids repetition (and possible eventual skew/mismatch) of the `reqwest` version number.