### PR TITLE
fix(services-aws-v4): Ensure token has been trimmed and encoded

### DIFF
--- a/core/src/hash.rs
+++ b/core/src/hash.rs
@@ -43,7 +43,7 @@ pub fn base64_decode(content: &str) -> crate::Result<Vec<u8>> {
 /// Use this function instead of `hex::encode(sha1(content))` can reduce
 /// extra copy.
 pub fn hex_sha1(content: &[u8]) -> String {
-    hex::encode(Sha1::digest(content).as_slice())
+    hex::encode(Sha1::digest(content))
 }
 
 /// Hex encoded SHA256 hash.
@@ -51,7 +51,7 @@ pub fn hex_sha1(content: &[u8]) -> String {
 /// Use this function instead of `hex::encode(sha256(content))` can reduce
 /// extra copy.
 pub fn hex_sha256(content: &[u8]) -> String {
-    hex::encode(Sha256::digest(content).as_slice())
+    hex::encode(Sha256::digest(content))
 }
 
 /// HMAC with SHA256 hash.

--- a/services/aws-v4/tests/signing/standard.rs
+++ b/services/aws-v4/tests/signing/standard.rs
@@ -67,7 +67,7 @@ async fn test_put_object() -> Result<()> {
 
     let cred = load_static_credential()?;
     let body = "Hello, World!";
-    let body_digest = hex::encode(Sha256::digest(body).as_slice());
+    let body_digest = hex::encode(Sha256::digest(body.as_bytes()));
 
     let mut req = Request::new(body.to_string());
     req.headers_mut().insert(


### PR DESCRIPTION
Fix part of https://github.com/apache/opendal/pull/6656

In the real world, token files may contain non-URL-safe characters. This PR handles them by trimming and encoding the tokens before sending them out.