### PR TITLE
feat(context-file-read-tokio): Allow file read tokio been built on wasm

### DIFF
--- a/context/file-read-tokio/Cargo.toml
+++ b/context/file-read-tokio/Cargo.toml
@@ -32,6 +32,8 @@ rust-version.workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 reqsign-core = { workspace = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { version = "1", features = ["fs"] }
 
 [dev-dependencies]

--- a/context/file-read-tokio/src/lib.rs
+++ b/context/file-read-tokio/src/lib.rs
@@ -74,11 +74,22 @@ use reqsign_core::{Error, FileRead, Result};
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TokioFileRead;
 
+#[cfg(not(target_family = "wasm"))]
 #[async_trait]
 impl FileRead for TokioFileRead {
     async fn file_read(&self, path: &str) -> Result<Vec<u8>> {
         tokio::fs::read(path)
             .await
             .map_err(|e| Error::unexpected("failed to read file").with_source(e))
+    }
+}
+
+#[cfg(target_family = "wasm")]
+#[async_trait]
+impl FileRead for TokioFileRead {
+    async fn file_read(&self, _path: &str) -> Result<Vec<u8>> {
+        Err(Error::unexpected(
+            "TokioFileRead is unsupported on wasm targets",
+        ))
     }
 }


### PR DESCRIPTION
Technically, file-read-tokio doesn't support WASM at all. But it's still useful to make this crate available on WASM so users don't have to juggle features and target configurations.