### PR TITLE
Bump version to 0.18.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,17 +27,17 @@ rust-version = "1.85.0"
 
 [workspace.dependencies]
 # Workspace dependencies
-reqsign-aliyun-oss = { version = "2.0.0", path = "services/aliyun-oss" }
-reqsign-aws-v4 = { version = "2.0.0", path = "services/aws-v4" }
-reqsign-azure-storage = { version = "2.0.0", path = "services/azure-storage" }
-reqsign-command-execute-tokio = { version = "2.0.0", path = "context/command-execute-tokio" }
-reqsign-core = { version = "2.0.0", path = "core" }
-reqsign-file-read-tokio = { version = "2.0.0", path = "context/file-read-tokio" }
-reqsign-google = { version = "2.0.0", path = "services/google" }
-reqsign-http-send-reqwest = { version = "2.0.0", path = "context/http-send-reqwest" }
-reqsign-huaweicloud-obs = { version = "2.0.0", path = "services/huaweicloud-obs" }
-reqsign-oracle = { version = "2.0.0", path = "services/oracle" }
-reqsign-tencent-cos = { version = "2.0.0", path = "services/tencent-cos" }
+reqsign-aliyun-oss = { version = "2.0.1", path = "services/aliyun-oss" }
+reqsign-aws-v4 = { version = "2.0.1", path = "services/aws-v4" }
+reqsign-azure-storage = { version = "2.0.1", path = "services/azure-storage" }
+reqsign-command-execute-tokio = { version = "2.0.1", path = "context/command-execute-tokio" }
+reqsign-core = { version = "2.0.1", path = "core" }
+reqsign-file-read-tokio = { version = "2.0.1", path = "context/file-read-tokio" }
+reqsign-google = { version = "2.0.1", path = "services/google" }
+reqsign-http-send-reqwest = { version = "2.0.1", path = "context/http-send-reqwest" }
+reqsign-huaweicloud-obs = { version = "2.0.1", path = "services/huaweicloud-obs" }
+reqsign-oracle = { version = "2.0.1", path = "services/oracle" }
+reqsign-tencent-cos = { version = "2.0.1", path = "services/tencent-cos" }
 
 # Crates.io dependencies
 anyhow = "1"

--- a/context/command-execute-tokio/Cargo.toml
+++ b/context/command-execute-tokio/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-command-execute-tokio"
-version = "2.0.0"
+version = "2.0.1"
 
 categories = ["asynchronous"]
 description = "Tokio-based command execution implementation for reqsign"

--- a/context/file-read-tokio/Cargo.toml
+++ b/context/file-read-tokio/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-file-read-tokio"
-version = "2.0.0"
+version = "2.0.1"
 
 categories = ["asynchronous"]
 description = "Tokio-based file reader implementation for reqsign"

--- a/context/http-send-reqwest/Cargo.toml
+++ b/context/http-send-reqwest/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-http-send-reqwest"
-version = "2.0.0"
+version = "2.0.1"
 
 categories = ["asynchronous"]
 description = "Reqwest-based HTTP client implementation for reqsign."

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-core"
-version = "2.0.0"
+version = "2.0.1"
 
 categories = ["command-line-utilities", "web-programming"]
 description = "Signing API requests without effort."

--- a/reqsign/Cargo.toml
+++ b/reqsign/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign"
-version = "0.18.0"
+version = "0.18.1"
 
 categories = ["authentication", "web-programming::http-client"]
 description = "Signing HTTP requests for AWS, Azure, Google, Huawei, Aliyun, Tencent and Oracle services"

--- a/services/aliyun-oss/Cargo.toml
+++ b/services/aliyun-oss/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-aliyun-oss"
-version = "2.0.0"
+version = "2.0.1"
 
 description = "Aliyun OSS signing implementation for reqsign."
 

--- a/services/aws-v4/Cargo.toml
+++ b/services/aws-v4/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-aws-v4"
-version = "2.0.0"
+version = "2.0.1"
 
 description = "AWS SigV4 signing implementation for reqsign."
 

--- a/services/azure-storage/Cargo.toml
+++ b/services/azure-storage/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-azure-storage"
-version = "2.0.0"
+version = "2.0.1"
 
 description = "Azure Storage signing implementation for reqsign."
 

--- a/services/google/Cargo.toml
+++ b/services/google/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-google"
-version = "2.0.0"
+version = "2.0.1"
 
 description = "Goole Cloud Platform signing implementation for reqsign."
 

--- a/services/huaweicloud-obs/Cargo.toml
+++ b/services/huaweicloud-obs/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-huaweicloud-obs"
-version = "2.0.0"
+version = "2.0.1"
 
 description = "Huawei Cloud OBS signing implementation for reqsign."
 

--- a/services/oracle/Cargo.toml
+++ b/services/oracle/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-oracle"
-version = "2.0.0"
+version = "2.0.1"
 
 description = "Oracle Cloud signing implementation for reqsign."
 

--- a/services/tencent-cos/Cargo.toml
+++ b/services/tencent-cos/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "reqsign-tencent-cos"
-version = "2.0.0"
+version = "2.0.1"
 
 description = "Tencent Cloud COS signing implementation for reqsign."
 


### PR DESCRIPTION
This PR will bump reqsign version to 0.18.1

All other crates bumped to 2.0.1


## Summary

- Enabled reqsign-http-send-reqwest and reqsign-file-read-tokio to build on WASM, tightening cross-platform coverage.
- Improved credential handling by returning credential_invalid when no credential is available and trimming/encoding AWS
  tokens correctly.
- Aligned internal crate versions for the 0.18.1/2.0.1 release and fixed the release workflow.

## Commits

- bd9eee5 Bump version to 0.18.1
- 4997eef feat: Make http-send-reqwest available on wasm (#656)
- 125362c feat: Return credential_invalid while no credential found (#655)
- c7953e5 feat(context-file-read-tokio): Allow file read tokio been built on wasm (#654)
- 1744efc fix(services-aws-v4): Ensure token has been trimmed and encoded (#653)
- 60d1ca9 ci: fix up release workflow (#650)

---

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**