### PR TITLE
chore: Fix typo in reqsign-google description

### DIFF
--- a/services/google/Cargo.toml
+++ b/services/google/Cargo.toml
@@ -19,7 +19,7 @@
 name = "reqsign-google"
 version = "2.0.1"
 
-description = "Goole Cloud Platform signing implementation for reqsign."
+description = "Google Cloud Platform signing implementation for reqsign."
 
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Replace “Goole” with “Google”