### PR TITLE
chore: upgrade reqwest to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ anyhow = "1"
 async-trait = "0.1"
 base64 = "0.22"
 bytes = "1"
-criterion = { version = "0.7.0", features = ["async_tokio", "html_reports"] }
+criterion = { version = "0.8.1", features = ["async_tokio", "html_reports"] }
 dotenv = "0.15"
 env_logger = "0.11"
 form_urlencoded = "1"
@@ -57,7 +57,7 @@ percent-encoding = "2"
 pretty_assertions = "1.3"
 quick-xml = { version = "0.38.1", features = ["serialize"] }
 rand = { version = "0.8.5" }
-reqwest = { version = "0.12", default-features = false }
+reqwest = { version = "0.13.1", default-features = false }
 rsa = { version = "0.9.2", features = ["pkcs5", "sha2"] }
 rust-ini = { version = "0.21" }
 serde = { version = "1", features = ["derive"] }

--- a/services/aliyun-oss/Cargo.toml
+++ b/services/aliyun-oss/Cargo.toml
@@ -41,5 +41,5 @@ dotenv = { workspace = true }
 env_logger = { workspace = true }
 reqsign-file-read-tokio = { workspace = true }
 reqsign-http-send-reqwest = { workspace = true }
-reqwest = { workspace = true, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["default-tls"] }
 tokio = { workspace = true, features = ["full"] }

--- a/services/aws-v4/Cargo.toml
+++ b/services/aws-v4/Cargo.toml
@@ -55,7 +55,7 @@ env_logger = { workspace = true }
 hex = { workspace = true }
 pretty_assertions = { workspace = true }
 reqsign-http-send-reqwest = { workspace = true }
-reqwest = { workspace = true, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["default-tls"] }
 sha2 = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/services/azure-storage/Cargo.toml
+++ b/services/azure-storage/Cargo.toml
@@ -51,5 +51,5 @@ env_logger = { workspace = true }
 reqsign-command-execute-tokio = { workspace = true }
 reqsign-file-read-tokio = { workspace = true }
 reqsign-http-send-reqwest = { workspace = true }
-reqwest = { workspace = true, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["default-tls"] }
 tokio = { workspace = true, features = ["full"] }

--- a/services/google/Cargo.toml
+++ b/services/google/Cargo.toml
@@ -46,6 +46,6 @@ dotenv = { workspace = true }
 env_logger = { workspace = true }
 reqsign-file-read-tokio = { workspace = true }
 reqsign-http-send-reqwest = { workspace = true }
-reqwest = { workspace = true, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["default-tls"] }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/services/google/src/sign_request.rs
+++ b/services/google/src/sign_request.rs
@@ -19,7 +19,6 @@ use http::header;
 use jsonwebtoken::{Algorithm, EncodingKey, Header as JwtHeader};
 use log::debug;
 use percent_encoding::{percent_decode_str, utf8_percent_encode};
-use rand::thread_rng;
 use rsa::pkcs1v15::SigningKey;
 use rsa::pkcs8::DecodePrivateKey;
 use rsa::signature::RandomizedSigner;
@@ -243,7 +242,7 @@ impl RequestSigner {
     }
 
     fn sign_with_service_account(private_key_pem: &str, string_to_sign: &str) -> Result<String> {
-        let mut rng = thread_rng();
+        let mut rng = rand::thread_rng();
         let private_key = rsa::RsaPrivateKey::from_pkcs8_pem(private_key_pem).map_err(|e| {
             reqsign_core::Error::unexpected("failed to parse private key").with_source(e)
         })?;

--- a/services/tencent-cos/Cargo.toml
+++ b/services/tencent-cos/Cargo.toml
@@ -42,5 +42,5 @@ env_logger = { workspace = true }
 reqsign-core = { workspace = true }
 reqsign-file-read-tokio = { workspace = true }
 reqsign-http-send-reqwest = { workspace = true }
-reqwest = { workspace = true, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["default-tls"] }
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
cc @Xuanwo Seems we need a new major version for `reqsign-http-send-reqwest` and all dependent crates.