### PR TITLE
Replace dotenv with dotenvy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ async-trait = "0.1"
 base64 = "0.22"
 bytes = "1"
 criterion = { version = "0.8.1", features = ["async_tokio", "html_reports"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 env_logger = "0.11"
 form_urlencoded = "1"
 hex = "0.4"

--- a/services/aliyun-oss/Cargo.toml
+++ b/services/aliyun-oss/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }
-dotenv = { workspace = true }
+dotenvy = { workspace = true }
 env_logger = { workspace = true }
 reqsign-file-read-tokio = { workspace = true }
 reqsign-http-send-reqwest = { workspace = true }

--- a/services/aliyun-oss/tests/main.rs
+++ b/services/aliyun-oss/tests/main.rs
@@ -33,7 +33,7 @@ use reqwest::Client;
 
 async fn init_signer() -> Option<(Context, Signer<reqsign_aliyun_oss::Credential>)> {
     let _ = env_logger::builder().is_test(true).try_init();
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
 
     if env::var("REQSIGN_ALIYUN_OSS_TEST").is_err()
         || env::var("REQSIGN_ALIYUN_OSS_TEST").unwrap() != "on"

--- a/services/aws-v4/Cargo.toml
+++ b/services/aws-v4/Cargo.toml
@@ -50,7 +50,7 @@ sha1 = "0.10"
 aws-credential-types = "1.1.8"
 aws-sigv4 = "1.2.0"
 criterion = { workspace = true }
-dotenv = { workspace = true }
+dotenvy = { workspace = true }
 env_logger = { workspace = true }
 hex = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/services/aws-v4/tests/credential_providers/mod.rs
+++ b/services/aws-v4/tests/credential_providers/mod.rs
@@ -37,7 +37,7 @@ use std::collections::HashMap;
 
 pub fn create_test_context() -> Context {
     let _ = env_logger::builder().is_test(true).try_init();
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
 
     let mut ctx = Context::new()
         .with_file_read(TokioFileRead)
@@ -54,7 +54,7 @@ pub fn create_test_context() -> Context {
 
 pub fn create_test_context_with_env(envs: HashMap<String, String>) -> Context {
     let _ = env_logger::builder().is_test(true).try_init();
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
 
     // Get home directory from HOME environment variable if set
     let home_dir = std::env::var("HOME").ok().map(std::path::PathBuf::from);

--- a/services/aws-v4/tests/signing/mod.rs
+++ b/services/aws-v4/tests/signing/mod.rs
@@ -48,7 +48,7 @@ pub fn load_static_credential() -> Result<Credential> {
 /// Initialize test environment
 pub fn init_signing_test() -> Option<(Context, RequestSigner, String)> {
     let _ = env_logger::builder().is_test(true).try_init();
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
 
     if env::var("REQSIGN_AWS_V4_TEST").is_err() || env::var("REQSIGN_AWS_V4_TEST").unwrap() != "on"
     {

--- a/services/google/Cargo.toml
+++ b/services/google/Cargo.toml
@@ -42,7 +42,7 @@ sha2 = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }
-dotenv = { workspace = true }
+dotenvy = { workspace = true }
 env_logger = { workspace = true }
 reqsign-file-read-tokio = { workspace = true }
 reqsign-http-send-reqwest = { workspace = true }

--- a/services/google/tests/credential_providers/mod.rs
+++ b/services/google/tests/credential_providers/mod.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 
 pub fn create_test_context() -> Context {
     let _ = env_logger::builder().is_test(true).try_init();
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
 
     Context::new()
         .with_file_read(TokioFileRead)
@@ -39,7 +39,7 @@ pub fn create_test_context() -> Context {
 
 pub fn create_test_context_with_env(envs: HashMap<String, String>) -> Context {
     let _ = env_logger::builder().is_test(true).try_init();
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
 
     let home_dir = std::env::var("HOME").ok().map(std::path::PathBuf::from);
 

--- a/services/google/tests/signing/signed_url.rs
+++ b/services/google/tests/signing/signed_url.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 
 async fn init_signer_for_signed_url() -> Option<(Context, Signer<Credential>)> {
     let _ = env_logger::builder().is_test(true).try_init();
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
 
     if env::var("REQSIGN_GOOGLE_TEST").unwrap_or_default() != "on" {
         return None;

--- a/services/google/tests/signing/standard.rs
+++ b/services/google/tests/signing/standard.rs
@@ -26,7 +26,7 @@ use std::env;
 
 async fn init_signer() -> Option<(Context, Signer<Credential>)> {
     let _ = env_logger::builder().is_test(true).try_init();
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
 
     if env::var("REQSIGN_GOOGLE_TEST").unwrap_or_default() != "on" {
         return None;

--- a/services/tencent-cos/Cargo.toml
+++ b/services/tencent-cos/Cargo.toml
@@ -37,7 +37,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-dotenv = { workspace = true }
+dotenvy = { workspace = true }
 env_logger = { workspace = true }
 reqsign-core = { workspace = true }
 reqsign-file-read-tokio = { workspace = true }

--- a/services/tencent-cos/tests/main.rs
+++ b/services/tencent-cos/tests/main.rs
@@ -34,7 +34,7 @@ use reqsign_tencent_cos::{Credential, RequestSigner, StaticCredentialProvider};
 
 async fn init_signer() -> Option<Signer<Credential>> {
     let _ = env_logger::builder().is_test(true).try_init();
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
     if env::var("REQSIGN_TENCENT_COS_TEST").is_err()
         || env::var("REQSIGN_TENCENT_COS_TEST").unwrap() != "on"
     {


### PR DESCRIPTION
dotenv is no longer maintained: https://rustsec.org/advisories/RUSTSEC-2021-0141.html
dotenvy seems like the best replacement: https://crates.io/crates/dotenvy