### PR TITLE
cargo: upgrade jsonwebtoken

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ hex = "0.4"
 hmac = "0.12"
 http = "1"
 jiff = "0.2"
+jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
 log = "0.4"
 percent-encoding = "2"
 pretty_assertions = "1.3"

--- a/services/azure-storage/Cargo.toml
+++ b/services/azure-storage/Cargo.toml
@@ -41,7 +41,7 @@ serde_json = { workspace = true }
 sha1 = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-jsonwebtoken = "9.2"
+jsonwebtoken = { workspace = true }
 pem = "3.0"
 rsa = { workspace = true }
 

--- a/services/google/Cargo.toml
+++ b/services/google/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 async-trait = { workspace = true }
 form_urlencoded = { workspace = true }
 http = { workspace = true }
-jsonwebtoken = "9.2"
+jsonwebtoken = { workspace = true }
 log = { workspace = true }
 percent-encoding = { workspace = true }
 rand = { workspace = true }


### PR DESCRIPTION
Move jsonwebtoken to a workspace dependency.
Upgrade to 10 series, to pick up CVE fix in 10.3.0.
Use aws-lc backend, as aws-lc is already an existing transitive
dependency.
